### PR TITLE
chore: update CI and deployment node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ou9999-dev",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "npm run generate && next build",


### PR DESCRIPTION
## Summary

- update GitHub Actions checkout/setup-node actions to v6
- pin deployment Node.js to 24.x for Vercel compatibility
- run CI with Node.js 24

## Verification

- npm ci --dry-run
- npm run lint
- npm run build
- GitHub Actions build passed
- Vercel Preview passed