### PR TITLE
feat: 콘텐츠 reveal 애니메이션 추가

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -59,7 +59,8 @@
 - 진입, stagger, viewport reveal, overlay 전환에 Motion 사용
 - 사진 reveal은 `clip-path: inset(0% 0% 100%)` → `inset(0%)` 마스크 방식 우선
 - 글 상세 대표 이미지는 preload 후 reveal 적용
-- 짧은 텍스트 인용문 reveal은 단어 단위 opacity stagger 사용
+- 짧은 텍스트 인용문 reveal은 Figma pull quote처럼 데스크톱 `90px/0.95`, 최대 `1032px`, 중앙 정렬 사용
+- 텍스트 인용문은 opening quote → 단어 → closing quote 순서로 opacity stagger 적용
 - MDX 텍스트 reveal은 서버 wrapper에서 적용 가능 여부를 판정하고 client 컴포넌트에는 문자열만 전달
 - 단순 hover·focus transition은 Tailwind 우선
 - 기본 preset: `/Users/ou9999/Documents/My Project/simple-blog/src/constant/motion-preset.ts`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -59,9 +59,11 @@
 - 진입, stagger, viewport reveal, overlay 전환에 Motion 사용
 - 사진 reveal은 `clip-path: inset(0% 0% 100%)` → `inset(0%)` 마스크 방식 우선
 - 글 상세 대표 이미지는 preload 후 reveal 적용
+- 짧은 텍스트 인용문 reveal은 단어 단위 opacity stagger 사용
+- MDX 텍스트 reveal은 서버 wrapper에서 적용 가능 여부를 판정하고 client 컴포넌트에는 문자열만 전달
 - 단순 hover·focus transition은 Tailwind 우선
 - 기본 preset: `/Users/ou9999/Documents/My Project/simple-blog/src/constant/motion-preset.ts`
-- `prefers-reduced-motion` 대응 시 `useReducedMotion`과 `motion-reduce` className 사용
+- `prefers-reduced-motion` 대응은 SSR hydration mismatch 방지를 위해 마크업 분기 없이 `motion-reduce:!` className 우선
 
 ## Redesign Notes
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -57,9 +57,11 @@
 - React 애니메이션 패키지 `motion` 사용
 - import 경로 `motion/react` 사용
 - 진입, stagger, viewport reveal, overlay 전환에 Motion 사용
+- 사진 reveal은 `clip-path: inset(0% 0% 100%)` → `inset(0%)` 마스크 방식 우선
+- 글 상세 대표 이미지는 preload 후 reveal 적용
 - 단순 hover·focus transition은 Tailwind 우선
 - 기본 preset: `/Users/ou9999/Documents/My Project/simple-blog/src/constant/motion-preset.ts`
-- `prefers-reduced-motion` 대응 시 `useReducedMotion` 우선
+- `prefers-reduced-motion` 대응 시 `useReducedMotion`과 `motion-reduce` className 사용
 
 ## Redesign Notes
 

--- a/src/components/content-header/content-header-motion.tsx
+++ b/src/components/content-header/content-header-motion.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { motion } from "motion/react";
 import {
   fadeUpPreset,
   heroImagePreset,
@@ -19,13 +19,10 @@ const ContentHeaderMotionRoot = ({
   children,
   className,
 }: ContentHeaderMotionProps) => {
-  const shouldReduceMotion = useReducedMotion();
-  const initialState = shouldReduceMotion ? false : "hidden";
-
   return (
     <motion.section
       className={className}
-      initial={initialState}
+      initial="hidden"
       animate="visible"
     >
       {children}
@@ -37,14 +34,11 @@ const ContentHeaderMotionImage = ({
   children,
   className,
 }: ContentHeaderMotionProps) => {
-  const shouldReduceMotion = useReducedMotion();
-  const initialState = shouldReduceMotion ? false : "hidden";
-
   return (
     <motion.div
       className={cn(className, "motion-reduce:![clip-path:inset(0%)]")}
       variants={heroImagePreset}
-      initial={initialState}
+      initial="hidden"
       animate="visible"
     >
       {children}
@@ -56,14 +50,11 @@ const ContentHeaderMotionText = ({
   children,
   className,
 }: ContentHeaderMotionProps) => {
-  const shouldReduceMotion = useReducedMotion();
-  const initialState = shouldReduceMotion ? false : "hidden";
-
   return (
     <motion.div
       className={className}
       variants={staggerContainerPreset}
-      initial={initialState}
+      initial="hidden"
       animate="visible"
     >
       {children}
@@ -76,7 +67,13 @@ const ContentHeaderMotionTitle = ({
   className,
 }: ContentHeaderMotionProps) => {
   return (
-    <motion.h1 className={className} variants={heroTitlePreset}>
+    <motion.h1
+      className={cn(
+        className,
+        "motion-reduce:!transform-none motion-reduce:!opacity-100",
+      )}
+      variants={heroTitlePreset}
+    >
       {children}
     </motion.h1>
   );
@@ -87,7 +84,13 @@ const ContentHeaderMotionItem = ({
   className,
 }: ContentHeaderMotionProps) => {
   return (
-    <motion.div className={className} variants={fadeUpPreset}>
+    <motion.div
+      className={cn(
+        className,
+        "motion-reduce:!transform-none motion-reduce:!opacity-100",
+      )}
+      variants={fadeUpPreset}
+    >
       {children}
     </motion.div>
   );

--- a/src/components/content-header/content-header-motion.tsx
+++ b/src/components/content-header/content-header-motion.tsx
@@ -8,6 +8,7 @@ import {
   heroTitlePreset,
   staggerContainerPreset,
 } from "@/constant/motion-preset";
+import { cn } from "@/utils/tailwind-util";
 
 interface ContentHeaderMotionProps {
   children: ReactNode;
@@ -41,7 +42,7 @@ const ContentHeaderMotionImage = ({
 
   return (
     <motion.div
-      className={className}
+      className={cn(className, "motion-reduce:![clip-path:inset(0%)]")}
       variants={heroImagePreset}
       initial={initialState}
       animate="visible"

--- a/src/components/content-header/content-header.tsx
+++ b/src/components/content-header/content-header.tsx
@@ -79,7 +79,7 @@ const ContentHeader = ({
               main && "bg-gradient-to-t from-gray-100 via-gray-300 to-gray-400"
             )}
           >
-            <ImageWithPlaceholderHeader alt={title} img={img} />
+            <ImageWithPlaceholderHeader alt={title} img={img} preload />
           </ContentHeaderMotionImage>
         )}
 

--- a/src/components/content-header/image-with-placeholder-header.tsx
+++ b/src/components/content-header/image-with-placeholder-header.tsx
@@ -4,11 +4,13 @@ import Image from "next/image";
 interface ImageWithPlaceholderHeaderProps {
   alt?: string;
   img: string;
+  preload?: boolean;
 }
 
 const ImageWithPlaceholderHeader = ({
   alt,
   img,
+  preload = false,
 }: ImageWithPlaceholderHeaderProps) => {
   const imgSrc = `/imgs/header/${img}.webp`;
   const base64Data = getBase64Header(`${img}.webp`);
@@ -19,6 +21,7 @@ const ImageWithPlaceholderHeader = ({
       src={imgSrc}
       fill
       sizes="(max-width: 768px) 100vw, 96vw"
+      preload={preload}
       placeholder="blur"
       blurDataURL={base64Data.base64}
     />

--- a/src/components/main-section/image-with-placeholder.tsx
+++ b/src/components/main-section/image-with-placeholder.tsx
@@ -1,19 +1,23 @@
 import { getBase64 } from "@/utils/base64-util";
 import { cn } from "@/utils/tailwind-util";
 import Image, { ImageProps } from "next/image";
+import { MediaReveal } from "./media-reveal";
 
 const ImageWithPlaceholder: React.FC<ImageProps> = (props) => {
   const base64Data = getBase64(props.src as string);
 
   return (
     <div className="relative flex flex-col justify-center items-center">
-      <Image
-        {...props}
-        alt={props.alt}
-        className={cn("rounded-lg w-auto h-auto max-w-full", props.className)}
-        placeholder="blur"
-        blurDataURL={base64Data.base64}
-      />
+      <MediaReveal className="inline-flex max-w-full">
+        <Image
+          {...props}
+          alt={props.alt}
+          className={cn("rounded-lg h-auto max-w-full", props.className)}
+          sizes={props.sizes ?? "(max-width: 768px) 100vw, 804px"}
+          placeholder="blur"
+          blurDataURL={base64Data.base64}
+        />
+      </MediaReveal>
       {props.alt && (
         <p className="my-1 text-gray-600 text-sm ">
           {props.alt}

--- a/src/components/main-section/mdx-blockquote.tsx
+++ b/src/components/main-section/mdx-blockquote.tsx
@@ -1,0 +1,110 @@
+import {
+  Children,
+  Fragment,
+  isValidElement,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { TextRevealBlockquote } from "./text-reveal-blockquote";
+
+type TextPart =
+  | {
+      type: "text";
+      value: string;
+    }
+  | {
+      type: "break";
+    };
+
+type MdxBlockquoteProps = ComponentPropsWithoutRef<"blockquote">;
+
+const maxRevealTokenCount = 32;
+const supportedElementNames = new Set(["p", "span"]);
+
+const isReactElement = (node: ReactNode): node is ReactElement<{
+  children?: ReactNode;
+}> => {
+  return isValidElement(node);
+};
+
+const getPlainTextParts = (node: ReactNode): TextPart[] | null => {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return [];
+  }
+
+  if (typeof node === "string" || typeof node === "number") {
+    return [{ type: "text", value: String(node) }];
+  }
+
+  if (Array.isArray(node)) {
+    const parts: TextPart[] = [];
+
+    for (const child of node) {
+      const childParts = getPlainTextParts(child);
+
+      if (!childParts) {
+        return null;
+      }
+
+      parts.push(...childParts);
+    }
+
+    return parts;
+  }
+
+  if (!isReactElement(node)) {
+    return null;
+  }
+
+  if (node.type === Fragment) {
+    return getPlainTextParts(node.props.children);
+  }
+
+  if (node.type === "br") {
+    return [{ type: "break" }];
+  }
+
+  if (typeof node.type !== "string" || !supportedElementNames.has(node.type)) {
+    return null;
+  }
+
+  return getPlainTextParts(node.props.children);
+};
+
+const getRevealText = (parts: TextPart[]): string | null => {
+  if (parts.some((part) => part.type === "break")) {
+    return null;
+  }
+
+  const text = parts
+    .map((part) => {
+      if (part.type === "break") {
+        return "";
+      }
+
+      return part.value;
+    })
+    .join("")
+    .trim();
+  const tokenCount = text.match(/\S+\s*/g)?.length ?? 0;
+
+  if (tokenCount === 0 || tokenCount > maxRevealTokenCount) {
+    return null;
+  }
+
+  return text;
+};
+
+const MdxBlockquote = ({ children, ...props }: MdxBlockquoteProps) => {
+  const parts = getPlainTextParts(Children.toArray(children));
+  const text = parts ? getRevealText(parts) : null;
+
+  if (!text) {
+    return <blockquote {...props}>{children}</blockquote>;
+  }
+
+  return <TextRevealBlockquote {...props} text={text} />;
+};
+
+export { MdxBlockquote };

--- a/src/components/main-section/mdx-blockquote.tsx
+++ b/src/components/main-section/mdx-blockquote.tsx
@@ -19,6 +19,11 @@ type TextPart =
 
 type MdxBlockquoteProps = ComponentPropsWithoutRef<"blockquote">;
 
+interface PullQuotePayload {
+  attribution?: string;
+  text: string;
+}
+
 const maxRevealTokenCount = 32;
 const supportedElementNames = new Set(["p", "span"]);
 
@@ -96,15 +101,66 @@ const getRevealText = (parts: TextPart[]): string | null => {
   return text;
 };
 
-const MdxBlockquote = ({ children, ...props }: MdxBlockquoteProps) => {
-  const parts = getPlainTextParts(Children.toArray(children));
-  const text = parts ? getRevealText(parts) : null;
+const getDirectChildren = (children: ReactNode): ReactNode[] => {
+  return Children.toArray(children).filter((child) => {
+    if (typeof child !== "string") {
+      return true;
+    }
 
-  if (!text) {
+    return child.trim().length > 0;
+  });
+};
+
+const getTextFromElement = (node: ReactNode): string | null => {
+  const parts = getPlainTextParts(node);
+
+  if (!parts) {
+    return null;
+  }
+
+  return getRevealText(parts);
+};
+
+const getPullQuotePayload = (
+  children: ReactNode,
+): PullQuotePayload | null => {
+  const directChildren = getDirectChildren(children);
+  const paragraphChildren = directChildren.filter((child) => {
+    return isReactElement(child) && child.type === "p";
+  });
+
+  if (directChildren.length === 1 && paragraphChildren.length === 1) {
+    const quoteText = getTextFromElement(paragraphChildren[0]);
+
+    if (!quoteText) {
+      return null;
+    }
+
+    return { text: quoteText };
+  }
+
+  if (directChildren.length === 2 && paragraphChildren.length === 2) {
+    const quoteText = getTextFromElement(paragraphChildren[0]);
+    const attribution = getTextFromElement(paragraphChildren[1]);
+
+    if (!quoteText || !attribution) {
+      return null;
+    }
+
+    return { attribution, text: quoteText };
+  }
+
+  return null;
+};
+
+const MdxBlockquote = ({ children, ...props }: MdxBlockquoteProps) => {
+  const payload = getPullQuotePayload(children);
+
+  if (!payload) {
     return <blockquote {...props}>{children}</blockquote>;
   }
 
-  return <TextRevealBlockquote {...props} text={text} />;
+  return <TextRevealBlockquote {...props} {...payload} />;
 };
 
 export { MdxBlockquote };

--- a/src/components/main-section/media-reveal.tsx
+++ b/src/components/main-section/media-reveal.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { viewportImagePreset } from "@/constant/motion-preset";
+import { cn } from "@/utils/tailwind-util";
+
+interface MediaRevealProps {
+  children: ReactNode;
+  className: string;
+}
+
+const MediaReveal = ({ children, className }: MediaRevealProps) => {
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return (
+      <div
+        key="reduced-media-reveal"
+        className={cn(className, "![clip-path:inset(0%)]")}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      key="motion-media-reveal"
+      className={cn(className, "motion-reduce:![clip-path:inset(0%)]")}
+      variants={viewportImagePreset}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0 }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export { MediaReveal };

--- a/src/components/main-section/media-reveal.tsx
+++ b/src/components/main-section/media-reveal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { motion } from "motion/react";
 import { viewportImagePreset } from "@/constant/motion-preset";
 import { cn } from "@/utils/tailwind-util";
 
@@ -11,19 +11,6 @@ interface MediaRevealProps {
 }
 
 const MediaReveal = ({ children, className }: MediaRevealProps) => {
-  const shouldReduceMotion = useReducedMotion();
-
-  if (shouldReduceMotion) {
-    return (
-      <div
-        key="reduced-media-reveal"
-        className={cn(className, "![clip-path:inset(0%)]")}
-      >
-        {children}
-      </div>
-    );
-  }
-
   return (
     <motion.div
       key="motion-media-reveal"

--- a/src/components/main-section/text-reveal-blockquote.tsx
+++ b/src/components/main-section/text-reveal-blockquote.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+import { motion } from "motion/react";
+import {
+  textRevealContainerPreset,
+  textRevealWordPreset,
+} from "@/constant/motion-preset";
+
+interface TextRevealBlockquoteProps
+  extends ComponentPropsWithoutRef<"blockquote"> {
+  text: string;
+}
+
+const TextRevealBlockquote = ({
+  text,
+  ...props
+}: TextRevealBlockquoteProps) => {
+  const tokens = text.match(/\S+\s*/g) ?? [];
+
+  return (
+    <blockquote {...props}>
+      <span className="sr-only">{text}</span>
+      <motion.span
+        aria-hidden="true"
+        className="motion-reduce:!opacity-100"
+        variants={textRevealContainerPreset}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.4 }}
+      >
+        {tokens.map((token, index) => {
+          return (
+            <motion.span
+              key={`${token}-${index}`}
+              className="motion-reduce:!opacity-100"
+              variants={textRevealWordPreset}
+            >
+              {token}
+            </motion.span>
+          );
+        })}
+      </motion.span>
+    </blockquote>
+  );
+};
+
+export { TextRevealBlockquote };

--- a/src/components/main-section/text-reveal-blockquote.tsx
+++ b/src/components/main-section/text-reveal-blockquote.tsx
@@ -6,42 +6,62 @@ import {
   textRevealContainerPreset,
   textRevealWordPreset,
 } from "@/constant/motion-preset";
+import { cn } from "@/utils/tailwind-util";
 
 interface TextRevealBlockquoteProps
   extends ComponentPropsWithoutRef<"blockquote"> {
+  attribution?: string;
   text: string;
 }
 
 const TextRevealBlockquote = ({
+  attribution,
+  className,
   text,
   ...props
 }: TextRevealBlockquoteProps) => {
-  const tokens = text.match(/\S+\s*/g) ?? [];
+  const tokens = ["“", ...(text.match(/\S+\s*/g) ?? []), "”"];
 
   return (
-    <blockquote {...props}>
-      <span className="sr-only">{text}</span>
-      <motion.span
-        aria-hidden="true"
-        className="motion-reduce:!opacity-100"
-        variants={textRevealContainerPreset}
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, amount: 0.4 }}
+    <figure className="not-prose relative left-1/2 my-28 w-[min(1032px,calc(100vw-48px))] -translate-x-1/2 text-center md:my-36">
+      <blockquote
+        {...props}
+        className={cn(
+          "m-0 border-0 p-0 text-center font-sans text-[3.625rem] font-normal leading-[1.05] tracking-normal text-google-paper lg:text-[5.625rem] lg:leading-[0.95]",
+          className,
+        )}
       >
-        {tokens.map((token, index) => {
-          return (
-            <motion.span
-              key={`${token}-${index}`}
-              className="motion-reduce:!opacity-100"
-              variants={textRevealWordPreset}
-            >
-              {token}
-            </motion.span>
-          );
-        })}
-      </motion.span>
-    </blockquote>
+        <span className="sr-only">{`“${text}”`}</span>
+        <motion.span
+          aria-hidden="true"
+          className="motion-reduce:!opacity-100"
+          variants={textRevealContainerPreset}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.4 }}
+        >
+          {tokens.map((token, index) => {
+            return (
+              <motion.span
+                key={`${token}-${index}`}
+                className={cn(
+                  "motion-reduce:!opacity-100",
+                  index === 0 && "-ml-[0.46em]",
+                )}
+                variants={textRevealWordPreset}
+              >
+                {token}
+              </motion.span>
+            );
+          })}
+        </motion.span>
+      </blockquote>
+      {attribution && (
+        <figcaption className="mt-8 text-center text-lg font-normal leading-[1.4] text-google-paper lg:mt-10 lg:text-xl">
+          {attribution}
+        </figcaption>
+      )}
+    </figure>
   );
 };
 

--- a/src/constant/motion-preset.ts
+++ b/src/constant/motion-preset.ts
@@ -38,16 +38,10 @@ const staggerContainerPreset = {
 
 const viewportImagePreset = {
   hidden: {
-    opacity: 0,
-    y: 72,
-    scale: 0.98,
-    clipPath: "inset(12% 0 0 0)",
+    clipPath: "inset(0% 0% 100%)",
   },
   visible: {
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    clipPath: "inset(0% 0 0 0)",
+    clipPath: "inset(0%)",
     transition: {
       duration: motionDuration.entrance,
       ease: editorialEase,
@@ -77,17 +71,12 @@ const overlayPreset = {
 
 const heroImagePreset = {
   hidden: {
-    opacity: 0,
-    y: 56,
-    scale: 0.98,
-    clipPath: "inset(50% 0 49% 0)",
+    clipPath: "inset(0% 0% 100%)",
   },
   visible: {
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    clipPath: "inset(0% 0 0 0)",
+    clipPath: "inset(0%)",
     transition: {
+      delay: motionStagger.base,
       duration: motionDuration.entrance,
       ease: editorialEase,
     },

--- a/src/constant/motion-preset.ts
+++ b/src/constant/motion-preset.ts
@@ -4,6 +4,7 @@ const motionDuration = {
   fast: 0.2,
   base: 0.4,
   entrance: 0.7,
+  textReveal: 0.32,
 };
 
 const motionStagger = {
@@ -98,6 +99,29 @@ const heroTitlePreset = {
   },
 };
 
+const textRevealContainerPreset = {
+  hidden: {},
+  visible: {
+    transition: {
+      delayChildren: 0.1,
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+const textRevealWordPreset = {
+  hidden: {
+    opacity: 0,
+  },
+  visible: {
+    opacity: 1,
+    transition: {
+      duration: motionDuration.textReveal,
+      ease: editorialEase,
+    },
+  },
+};
+
 export {
   editorialEase,
   fadeUpPreset,
@@ -107,5 +131,7 @@ export {
   motionStagger,
   overlayPreset,
   staggerContainerPreset,
+  textRevealContainerPreset,
+  textRevealWordPreset,
   viewportImagePreset,
 };

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,10 +1,12 @@
 import { ImageWithPlaceholder } from "@/components/main-section/image-with-placeholder";
+import { MdxBlockquote } from "@/components/main-section/mdx-blockquote";
 import { VideoWithAlt } from "@/components/main-section/video-with-alt";
 import type { MDXComponents } from "mdx/types";
 
 const mdxComponents: MDXComponents = {
   Image: ImageWithPlaceholder,
   Video: VideoWithAlt,
+  blockquote: MdxBlockquote,
 };
 
 const useMDXComponents = (components: MDXComponents): MDXComponents => {


### PR DESCRIPTION
## 요약

- 사진과 본문 미디어에 reveal 애니메이션을 적용함
- 짧은 인용문을 큰 pull quote 레이아웃과 단어 단위 등장 애니메이션으로 확장함
- 감소 모션과 hydration mismatch를 방지하도록 모션 처리 방식을 정리함

### 미디어 reveal

- 대표 이미지와 본문 이미지가 뷰포트 진입 시 위에서 아래로 열리는 마스크 방식으로 나타나도록 통일함.

### 텍스트 pull quote

- 짧은 텍스트 인용문은 넓은 중앙 정렬 quote로 표시하고, 여는 따옴표부터 단어와 닫는 따옴표까지 순차적으로 등장하도록 구현함.
- 두 문단짜리 인용문은 두 번째 문단을 출처로 표시할 수 있게 확장함.

### 접근성 및 안정성

- 감소 모션 환경에서는 애니메이션 없이 콘텐츠가 즉시 보이도록 처리함.
- 서버와 클라이언트의 초기 마크업 차이를 줄여 hydration 경고가 발생하지 않도록 정리함.