### PR TITLE
feat: Mineral Wash 구아슈 테마 적용

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,7 +7,7 @@
 - Mineral Wash 컬러 우선
 - 거의 검정에 가까운 graphite black 배경과 cool off-white 텍스트를 기본 표면으로 사용
 - 링크·행동 색상은 Blue Steel 기반의 저채도 cool gray-blue 계열 사용
-- 강조 색상은 graphite/oxide 계열을 제한적으로 사용하고 노란 기운은 피함
+- 강조 색상은 Blue Steel silver-blue를 기본으로 사용하고, graphite/oxide 계열은 보조 질감으로만 제한
 - 테마 모드 명칭보다 레퍼런스 색상 일치 우선
 - 브라우저 기본 UI는 dark color-scheme 기준
 
@@ -35,7 +35,7 @@
   - `text-transparent`
   - Mineral Wash 표면 그라데이션은 거의 단색의 black/graphite 범위로 제한
   - 텍스트 그라데이션은 `bg-mineral-lettering`으로 분리하고 Blue Steel 기준의 silver-blue 명도 차만 사용
-  - 붓질 질감은 fixed viewport 배경 레이어 또는 프레임에만 낮은 opacity로 제한
+  - 붓질 질감은 fixed viewport 배경 레이어 또는 프레임에 낮은 opacity로 제한하고, 텍스트에는 선택된 하이라이트 hover stroke에만 사용
   - 자개 그라데이션은 흰 자개·연분홍·연보라·은청색 비중을 높이고 강한 청록·네온 블루는 제한
   - 자개 토큰은 `/test/jagae`와 실험 보존용이며 기본 블로그 UI에는 Mineral Wash 토큰 우선
 - 폰트
@@ -60,7 +60,8 @@
 ## Components
 
 - 조건부 className 조합은 `cn` 사용
-- hover·focus 상태는 Tailwind className으로 표현
+- 일반 hover·focus 상태는 Tailwind className으로 표현
+- 붓칠처럼 그려지는 hover 인터랙션은 `motion/react`로 상태와 stroke 진행을 제어
 - inline style 금지
 - SVG 고정 색상은 SVG 속성 사용
 
@@ -69,6 +70,8 @@
 - React 애니메이션 패키지 `motion` 사용
 - import 경로 `motion/react` 사용
 - 진입, stagger, viewport reveal, overlay 전환에 Motion 사용
+- 하이라이트 붓칠 hover는 SVG stroke를 `pathLength`로 그리는 방식 우선
+- 하이라이트 붓칠 hover는 텍스트 내부를 덧칠하지 않고 텍스트 주변/뒤쪽 stroke 레이어로 표현
 - 사진 reveal은 `clip-path: inset(0% 0% 100%)` → `inset(0%)` 마스크 방식 우선
 - 글 상세 대표 이미지는 preload 후 reveal 적용
 - 짧은 텍스트 인용문 reveal은 Figma pull quote처럼 데스크톱 `90px/0.95`, 최대 `1032px`, 중앙 정렬 사용
@@ -83,5 +86,6 @@
 - Figma 스타일 개편 TODO: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-blog-redesign-todo.md`
 - Figma 레퍼런스 탐색 기록: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-blog-style.md`
 - Figma 비주얼 아이덴티티: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-visual-identity.md`
-- `/test/color`의 Mineral Wash 후보를 기본 블로그 컬러 방향으로 적용
-- `/test/jagae`와 `/test/gouache`는 보존하되 기본 블로그 UI에는 직접 적용하지 않음
+- `/test/color`의 Mineral Wash와 Blue Steel 하이라이트를 기본 블로그 컬러 방향으로 적용
+- `/test/color`의 붓칠 hover는 하이라이트 인터랙션 후보로 보존하고, 전역 적용 전 해당 페이지에서 검증
+- `/test/jagae`는 보존용 실험 페이지, `/test/gouache`는 fixed gouache layer 기준 확인 페이지로 유지

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@
 
 - Mineral Wash 컬러 우선
 - 거의 검정에 가까운 graphite black 배경과 cool off-white 텍스트를 기본 표면으로 사용
-- 링크·행동 색상은 저채도 cool gray-blue 계열 사용
+- 링크·행동 색상은 Blue Steel 기반의 저채도 cool gray-blue 계열 사용
 - 강조 색상은 graphite/oxide 계열을 제한적으로 사용하고 노란 기운은 피함
 - 테마 모드 명칭보다 레퍼런스 색상 일치 우선
 - 브라우저 기본 UI는 dark color-scheme 기준
@@ -34,7 +34,7 @@
   - `bg-clip-text`
   - `text-transparent`
   - Mineral Wash 표면 그라데이션은 거의 단색의 black/graphite 범위로 제한
-  - 텍스트 그라데이션은 `bg-mineral-lettering`으로 분리하고 cool off-white 내부 명도 차만 사용
+  - 텍스트 그라데이션은 `bg-mineral-lettering`으로 분리하고 Blue Steel 기준의 silver-blue 명도 차만 사용
   - 붓질 질감은 fixed viewport 배경 레이어 또는 프레임에만 낮은 opacity로 제한
   - 자개 그라데이션은 흰 자개·연분홍·연보라·은청색 비중을 높이고 강한 청록·네온 블루는 제한
   - 자개 토큰은 `/test/jagae`와 실험 보존용이며 기본 블로그 UI에는 Mineral Wash 토큰 우선

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,10 +4,10 @@
 
 ## Mode
 
-- Google Design 컬러 우선
-- 나전칠기 흑칠처럼 순검정보다 살짝 밝은 warm lacquer black 배경과 white 텍스트를 기본 표면으로 사용
-- 링크·행동 색상은 Google blue 사용
-- 강조 색상은 Google yellow를 제한적으로 사용
+- Mineral Wash 컬러 우선
+- 거의 검정에 가까운 graphite black 배경과 cool off-white 텍스트를 기본 표면으로 사용
+- 링크·행동 색상은 저채도 cool gray-blue 계열 사용
+- 강조 색상은 graphite/oxide 계열을 제한적으로 사용하고 노란 기운은 피함
 - 테마 모드 명칭보다 레퍼런스 색상 일치 우선
 - 브라우저 기본 UI는 dark color-scheme 기준
 
@@ -16,17 +16,28 @@
 - 배경
   - `bg-google-ink`
   - `bg-google-paper`
+  - `bg-mineral-canvas`
+  - `bg-mineral-frame`
 - 색상
   - `text-google-ink`
   - `text-google-paper`
   - `text-google-blue`
   - `text-google-muted`
   - `text-google-yellow`
+  - `text-mineral-teal`
+  - `text-mineral-blue`
+  - `text-mineral-bone`
 - 텍스트 그라데이션
+  - `bg-mineral-wash`
+  - `bg-mineral-lettering`
   - `bg-nacre-moonlit`
   - `bg-clip-text`
   - `text-transparent`
+  - Mineral Wash 표면 그라데이션은 거의 단색의 black/graphite 범위로 제한
+  - 텍스트 그라데이션은 `bg-mineral-lettering`으로 분리하고 cool off-white 내부 명도 차만 사용
+  - 붓질 질감은 fixed viewport 배경 레이어 또는 프레임에만 낮은 opacity로 제한
   - 자개 그라데이션은 흰 자개·연분홍·연보라·은청색 비중을 높이고 강한 청록·네온 블루는 제한
+  - 자개 토큰은 `/test/jagae`와 실험 보존용이며 기본 블로그 UI에는 Mineral Wash 토큰 우선
 - 폰트
   - `font-sans`
   - `LINE Seed Sans KR`
@@ -72,4 +83,5 @@
 - Figma 스타일 개편 TODO: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-blog-redesign-todo.md`
 - Figma 레퍼런스 탐색 기록: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-blog-style.md`
 - Figma 비주얼 아이덴티티: `/Users/ou9999/Documents/My Project/simple-blog/.progress/260613/figma-visual-identity.md`
-- 구아슈 썸네일 시스템 확정 후 이 문서의 Tokens 보강
+- `/test/color`의 Mineral Wash 후보를 기본 블로그 컬러 방향으로 적용
+- `/test/jagae`와 `/test/gouache`는 보존하되 기본 블로그 UI에는 직접 적용하지 않음

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,7 +5,7 @@
 ## Mode
 
 - Google Design 컬러 우선
-- warm black 배경과 white 텍스트를 기본 표면으로 사용
+- 나전칠기 흑칠처럼 순검정보다 살짝 밝은 warm lacquer black 배경과 white 텍스트를 기본 표면으로 사용
 - 링크·행동 색상은 Google blue 사용
 - 강조 색상은 Google yellow를 제한적으로 사용
 - 테마 모드 명칭보다 레퍼런스 색상 일치 우선
@@ -26,6 +26,7 @@
   - `bg-nacre-moonlit`
   - `bg-clip-text`
   - `text-transparent`
+  - 자개 그라데이션은 흰 자개·연분홍·연보라·은청색 비중을 높이고 강한 청록·네온 블루는 제한
 - 폰트
   - `font-sans`
   - `LINE Seed Sans KR`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm generate && next build",
+    "build": "pnpm generate && next build && node src/scripts/remove-test-output.mjs",
     "start": "next start",
     "lint": "eslint .",
     "generate": "node src/scripts/generate-base64.mjs"

--- a/src/app/(about-layout)/about/page.tsx
+++ b/src/app/(about-layout)/about/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
 
 const PortfolioLink = () => {
   return (
-    <div className="w-full flex justify-center mt-14">
+    <div className="mt-14 flex w-full justify-center">
       <Link href={"/portfolio"}>
-        <div className="rotated_gradient_box font-semibold rounded-md p-[1px] cursor-pointer hover:group group">
-          <div className="flex justify-center items-center w-full bg-content-header-black rounded-md px-3 py-1">
-            <p className="inline-block bg-gradient-to-r from-white to-white text-transparent bg-clip-text group-hover:from-gradient-start group-hover:to-gradient-end">
+        <div className="group cursor-pointer rounded-md bg-mineral-lettering p-[1px] font-semibold shadow-[0_18px_60px_rgb(4_8_8/0.22)]">
+          <div className="flex w-full items-center justify-center rounded-md bg-content-header-black px-3 py-1">
+            <p className="inline-block bg-gradient-to-r from-google-paper to-google-paper bg-clip-text text-transparent group-hover:from-gradient-start group-hover:to-gradient-end">
               Portfolio
             </p>
           </div>

--- a/src/app/(about-layout)/popover/page.tsx
+++ b/src/app/(about-layout)/popover/page.tsx
@@ -15,7 +15,7 @@ interface ILinkButtonProps {
 
 const LinkButton = ({ text, link }: ILinkButtonProps) => {
   return (
-    <Link href={link} className="text-2xl font-semibold">
+    <Link href={link} className="text-2xl font-semibold hover:text-mineral-blue">
       {text}
     </Link>
   );
@@ -29,11 +29,11 @@ interface ITagItemProps {
 const TagItem = ({ title, count }: ITagItemProps) => {
   return (
     <Link href={`/tags/${title}`}>
-      <div className="w-full flex rounded-md py-1 px-3 items-center">
-        <p className="cursor-pointer text-gradient-start hover:underline">
+      <div className="flex w-full items-center rounded-md px-3 py-1">
+        <p className="cursor-pointer text-mineral-blue hover:underline">
           {title.toUpperCase()}
         </p>
-        <p className="text-slate-400 text-xs">&nbsp;({count})</p>
+        <p className="text-xs text-google-muted">&nbsp;({count})</p>
       </div>
     </Link>
   );
@@ -43,17 +43,17 @@ const MobilePopover = async () => {
   const tagsCount = await getTagsFromPosts();
 
   return (
-    <div className="fixed top-0 left-0 right-0 bottom-0 z-50 w-dvw h-dvh overflow-y-auto bg-dark-bg">
-      <div className="w-full min-h-dvh flex flex-col justify-start items-center relative">
+    <div className="fixed bottom-0 left-0 right-0 top-0 z-50 h-dvh w-dvw overflow-y-auto bg-dark-bg">
+      <div className="relative flex min-h-dvh w-full flex-col items-center justify-start">
         <BackButton />
-        <p className="mt-20 mb-7 font-bold text-4xl">Menu</p>
-        <div className="flex flex-col justify-center items-center space-y-3">
+        <p className="mb-7 mt-20 text-4xl font-bold">Menu</p>
+        <div className="flex flex-col items-center justify-center space-y-3">
           <LinkButton text="Home" link="/" />
           <LinkButton text="About" link="/about" />
           <LinkButton text="Portfolio" link="/portfolio" />
         </div>
-        <p className="mt-20 mb-7 font-bold text-4xl">Tag</p>
-        <div className="flex flex-col justify-center items-center space-y-3 ">
+        <p className="mb-7 mt-20 text-4xl font-bold">Tag</p>
+        <div className="flex flex-col items-center justify-center space-y-3">
           {tagsCount?.map((tag) => (
             <TagItem
               key={"POPOVERTAGITEM" + tag.tag}

--- a/src/app/(blog-layout)/p/[title]/page.tsx
+++ b/src/app/(blog-layout)/p/[title]/page.tsx
@@ -57,7 +57,7 @@ const PostPage = async ({ params }: IPostPageProps) => {
 
   return (
     <>
-      <article className="w-full overflow-x-hidden bg-google-ink text-google-paper">
+      <article className="w-full overflow-x-hidden bg-transparent text-google-paper">
         <ContentHeader
           title={post.title}
           text={post.description}
@@ -65,11 +65,11 @@ const PostPage = async ({ params }: IPostPageProps) => {
           tags={post.tags}
           date={post.date}
         />
-        <div className="mx-auto w-full max-w-[684px] px-6 pb-20 pt-28 prose prose-google prose-img:mb-0 prose-p:my-6 prose-p:text-xl prose-p:font-normal prose-p:leading-7 prose-p:text-google-paper prose-headings:font-normal prose-headings:text-google-paper prose-h2:mb-10 prose-h2:mt-20 prose-h2:text-5xl prose-h2:leading-tight prose-blockquote:not-italic prose-blockquote:font-normal prose-blockquote:text-google-paper prose-a:bg-nacre-moonlit prose-a:bg-clip-text prose-a:text-transparent prose-quoteless prose-blockquote:border-google-blue prose-strong:text-google-paper prose-video:mb-0 md:px-0 md:pb-28 md:pt-[327px] md:prose-h2:text-[64px] md:prose-h2:leading-[67px] 2xl:max-w-[804px] 2xl:pt-[361px]">
+        <div className="mx-auto w-full max-w-[684px] px-6 pb-20 pt-28 prose prose-google prose-img:mb-0 prose-p:my-6 prose-p:text-xl prose-p:font-normal prose-p:leading-7 prose-p:text-google-paper prose-headings:font-normal prose-headings:text-google-paper prose-h2:mb-10 prose-h2:mt-20 prose-h2:text-5xl prose-h2:leading-tight prose-blockquote:not-italic prose-blockquote:font-normal prose-blockquote:text-google-paper prose-a:bg-mineral-lettering prose-a:bg-clip-text prose-a:text-transparent prose-quoteless prose-blockquote:border-mineral-teal prose-strong:text-google-paper prose-video:mb-0 md:px-0 md:pb-28 md:pt-[327px] md:prose-h2:text-[64px] md:prose-h2:leading-[67px] 2xl:max-w-[804px] 2xl:pt-[361px]">
           <Mdx Component={MdxComponent} />
         </div>
       </article>
-      <div className="w-full bg-google-ink">
+      <div className="w-full bg-transparent">
         <div className="mx-auto w-full max-w-[684px] px-6 md:px-0 2xl:max-w-[804px]">
           <GiscusComment />
         </div>

--- a/src/app/(blog-layout)/page.tsx
+++ b/src/app/(blog-layout)/page.tsx
@@ -12,7 +12,7 @@ const HomePage = () => {
         text="노력과 고민을 담아 기록한 글"
         main
       />
-      <section className="w-full bg-google-ink px-6 py-16 text-google-paper">
+      <section className="w-full bg-transparent px-6 py-16 text-google-paper">
         <div className="mx-auto w-full max-w-[1632px]">
           <div className="mb-14 flex flex-col gap-3 md:mb-20 md:flex-row md:items-end md:justify-between">
             <h2 className="text-4xl font-normal leading-tight text-current md:text-[64px] md:leading-[67px]">

--- a/src/app/(blog-layout)/tags/[tag]/page.tsx
+++ b/src/app/(blog-layout)/tags/[tag]/page.tsx
@@ -42,7 +42,7 @@ const TagPage = async ({ params }: ITagPageProps) => {
   return (
     <>
       <ContentHeader title={`TAG : ${tag}`} text="같은 맥락으로 묶인 글" main />
-      <section className="w-full bg-google-ink px-6 py-16 text-google-paper">
+      <section className="w-full bg-transparent px-6 py-16 text-google-paper">
         <div className="mx-auto w-full max-w-[1632px]">
           <div className="mb-14 flex flex-col gap-3 md:mb-20 md:flex-row md:items-end md:justify-between">
             <h2 className="text-4xl font-normal leading-tight text-current md:text-[64px] md:leading-[67px]">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "@kfonts/line-seed-sans-kr/index.css";
 import "@/css/tailwind.css";
 import "@/css/prettyCode.css";
 import { defaultOpenGraph, defaultTwitter } from "@/constant/meta-data";
+import { MineralWashBackground } from "@/components/background/mineral-wash-background";
 import { Footer } from "@/components/nav/site-footer";
 import { myDomain } from "@/constant/domain";
 import { Header } from "@/components/nav/site-header";
@@ -36,9 +37,10 @@ const RootLayout = ({
 }) => {
   return (
     <html lang="en">
-      <body className="bg-google-ink text-google-paper font-sans">
+      <body className="min-h-dvh overflow-x-hidden bg-google-ink text-google-paper font-sans antialiased">
+        <MineralWashBackground />
         <Header />
-        {children}
+        <div className="relative z-10">{children}</div>
         <Footer />
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,10 +2,12 @@ import Link from "next/link";
 
 const NotFound = () => {
   return (
-    <div className="w-dvw h-dvh flex justify-center items-center flex-col space-y-10">
-      <p className="font-bold text-9xl">404</p>
+    <div className="flex h-dvh w-dvw flex-col items-center justify-center space-y-10">
+      <p className="bg-mineral-lettering bg-clip-text text-9xl font-bold text-transparent">
+        404
+      </p>
       <Link href={"/"}>
-        <button className="px-5 py-3 font-bold rounded-lg bg-content-header-black">
+        <button className="rounded-lg border-1 border-mineral-blue/22 bg-content-header-black px-5 py-3 font-bold text-google-paper transition-colors hover:border-mineral-blue/60 hover:text-mineral-blue">
           GO HOME
         </button>
       </Link>

--- a/src/app/test/color/color.module.css
+++ b/src/app/test/color/color.module.css
@@ -53,6 +53,95 @@
   transform: rotate(-5deg);
 }
 
+.gradientCard {
+  isolation: isolate;
+}
+
+.gradientCard::before {
+  position: absolute;
+  inset: -22% -14% auto;
+  z-index: 0;
+  height: 58%;
+  pointer-events: none;
+  content: "";
+  opacity: 0.5;
+  background:
+    radial-gradient(ellipse at 20% 56%, rgb(162 173 179 / 0.12), transparent 36%),
+    radial-gradient(ellipse at 70% 32%, rgb(31 42 40 / 0.18), transparent 42%),
+    linear-gradient(104deg, transparent 0 18%, rgb(232 236 236 / 0.055) 28%, transparent 46% 100%);
+  filter: url("#color-gouache-bristle") blur(0.7px);
+  mix-blend-mode: screen;
+  transform: rotate(-4deg);
+}
+
+.gradientText {
+  display: inline-block;
+  color: transparent;
+  text-wrap: balance;
+  background-size: 132% 100%;
+  background-position: 50% 50%;
+  background-clip: text;
+  filter: drop-shadow(0 0 18px rgb(162 173 179 / 0.16));
+  -webkit-text-fill-color: transparent;
+  -webkit-background-clip: text;
+}
+
+.gradientColdPearl {
+  background-image: linear-gradient(
+    112deg,
+    #ffffff 0%,
+    #eef2f2 20%,
+    #aebbc0 48%,
+    #fbfdfd 72%,
+    #cad4d6 100%
+  );
+}
+
+.gradientBlueSteel {
+  background-image: linear-gradient(
+    112deg,
+    #f8fbfb 0%,
+    #d4e5ec 24%,
+    #a2adb3 48%,
+    #e5eef1 72%,
+    #ffffff 100%
+  );
+}
+
+.gradientMineralTeal {
+  background-image: linear-gradient(
+    112deg,
+    #f2f7f5 0%,
+    #bfd2cf 24%,
+    #7f9f99 48%,
+    #e8ecec 72%,
+    #a2adb3 100%
+  );
+}
+
+.gradientOxideAsh {
+  background-image: linear-gradient(
+    112deg,
+    #faf8f3 0%,
+    #d4cbc3 24%,
+    #988d86 48%,
+    #e8ecec 74%,
+    #b9c2c4 100%
+  );
+}
+
+.gradientHardChalk {
+  background-image: linear-gradient(
+    112deg,
+    #ffffff 0%,
+    #ffffff 18%,
+    #e8ecec 36%,
+    #a2adb3 54%,
+    #fdfefe 74%,
+    #c4d0d3 100%
+  );
+}
+
 .previewSurface {
   isolation: isolate;
   --gouache-primary: 31 42 40;

--- a/src/app/test/color/color.module.css
+++ b/src/app/test/color/color.module.css
@@ -72,6 +72,242 @@
       96deg,
       rgb(25 23 20 / 0.1) 0 1px,
       transparent 1px 13px
-    );
+  );
   mix-blend-mode: multiply;
+}
+
+.candidateSurface {
+  isolation: isolate;
+  --gouache-primary: 245 238 222;
+  --gouache-secondary: 156 116 80;
+  --gouache-light: 245 238 222;
+  --gouache-shadow: 0 0 0;
+  background:
+    linear-gradient(145deg, rgb(245 238 222 / 0.045), rgb(255 255 255 / 0.015)),
+    #191714;
+}
+
+.candidateInkBone {
+  --gouache-primary: 156 116 80;
+  --gouache-secondary: 58 50 42;
+  --gouache-light: 245 238 222;
+  --gouache-shadow: 0 0 0;
+}
+
+.candidateMineral {
+  --gouache-primary: 66 83 79;
+  --gouache-secondary: 75 89 121;
+  --gouache-light: 157 175 197;
+  --gouache-shadow: 4 8 8;
+}
+
+.candidateSienna {
+  --gouache-primary: 126 69 61;
+  --gouache-secondary: 183 127 82;
+  --gouache-light: 245 238 222;
+  --gouache-shadow: 16 8 5;
+}
+
+.candidateViolet {
+  --gouache-primary: 109 83 98;
+  --gouache-secondary: 154 107 112;
+  --gouache-light: 185 172 201;
+  --gouache-shadow: 8 5 10;
+}
+
+.gouacheLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.gouacheLayer::before,
+.gouacheLayer::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+}
+
+.gouacheLayer::before {
+  z-index: 1;
+  opacity: 0.28;
+  background:
+    repeating-linear-gradient(
+      108deg,
+      rgb(var(--gouache-light) / 0.08) 0 1px,
+      transparent 1px 13px
+    ),
+    repeating-linear-gradient(
+      18deg,
+      rgb(0 0 0 / 0.28) 0 1px,
+      transparent 1px 17px
+    );
+  filter: url("#color-gouache-paper") contrast(1.18);
+  mix-blend-mode: soft-light;
+}
+
+.gouacheLayer::after {
+  z-index: 2;
+  opacity: 0.2;
+  background:
+    radial-gradient(circle at 18% 42%, rgb(var(--gouache-light) / 0.22) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 78% 18%, rgb(var(--gouache-secondary) / 0.18) 0 1px, transparent 1px 6px);
+  background-size:
+    10px 10px,
+    15px 15px;
+  mix-blend-mode: screen;
+}
+
+.gouacheTexture {
+  position: absolute;
+  pointer-events: none;
+  filter: url("#color-gouache-bristle") blur(0.4px);
+  transform-origin: center;
+}
+
+.gouacheShadow {
+  left: -20%;
+  bottom: -40%;
+  z-index: 3;
+  width: 68%;
+  height: 58%;
+  opacity: 0.5;
+  background:
+    radial-gradient(ellipse at 38% 50%, rgb(var(--gouache-shadow) / 0.78) 0 22%, rgb(var(--gouache-primary) / 0.1) 44%, transparent 72%),
+    conic-gradient(from 224deg at 52% 54%, transparent 0 20%, rgb(var(--gouache-secondary) / 0.16) 28% 38%, transparent 48% 100%);
+  border-radius: 54% 42% 56% 38%;
+  mix-blend-mode: multiply;
+  transform: rotate(-10deg) skewX(-6deg);
+}
+
+.gouachePrimary {
+  right: -22%;
+  top: -20%;
+  z-index: 4;
+  width: 60%;
+  height: 70%;
+  opacity: 0.56;
+  background:
+    radial-gradient(ellipse at 42% 48%, rgb(var(--gouache-primary) / 0.58) 0 13%, rgb(var(--gouache-secondary) / 0.28) 30%, transparent 64%),
+    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(var(--gouache-light) / 0.2) 24% 31%, rgb(var(--gouache-primary) / 0.26) 38% 48%, transparent 58% 100%);
+  border-radius: 44% 58% 40% 54%;
+  mix-blend-mode: screen;
+  transform: rotate(15deg) skewX(4deg);
+}
+
+.gouacheSecondary {
+  left: -12%;
+  top: 4%;
+  z-index: 5;
+  width: 62%;
+  height: 72%;
+  opacity: 0.4;
+  background:
+    linear-gradient(62deg, transparent 0 13%, rgb(var(--gouache-secondary) / 0.58) 27%, rgb(var(--gouache-primary) / 0.26) 49%, transparent 73%),
+    radial-gradient(ellipse at 38% 46%, rgb(var(--gouache-light) / 0.13) 0 16%, transparent 45%);
+  border-radius: 58% 42% 54% 38%;
+  mix-blend-mode: screen;
+  transform: rotate(-18deg) skewY(7deg);
+}
+
+.gouacheLight {
+  left: 33%;
+  top: 3%;
+  z-index: 6;
+  width: 50%;
+  height: 86%;
+  opacity: 0.24;
+  background:
+    radial-gradient(ellipse at 42% 38%, rgb(var(--gouache-light) / 0.46) 0 12%, rgb(var(--gouache-light) / 0.2) 30%, transparent 62%),
+    conic-gradient(from 194deg at 52% 48%, transparent 0 18%, rgb(var(--gouache-light) / 0.22) 23% 31%, transparent 39% 100%),
+    repeating-linear-gradient(
+      103deg,
+      transparent 0 15px,
+      rgb(var(--gouache-light) / 0.16) 17px 20px,
+      transparent 23px 44px
+    );
+  border-radius: 44% 58% 38% 54%;
+  mix-blend-mode: screen;
+  transform: rotate(14deg) skewY(-6deg);
+}
+
+.gouacheDryLine {
+  position: absolute;
+  right: -8%;
+  top: 0;
+  z-index: 7;
+  width: 44%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.18;
+  background:
+    repeating-linear-gradient(
+      103deg,
+      transparent 0 20px,
+      rgb(var(--gouache-light) / 0.22) 22px 24px,
+      transparent 26px 54px
+    );
+  filter: url("#color-gouache-bristle") blur(1px);
+  mix-blend-mode: screen;
+  transform: rotate(3deg);
+}
+
+.gouacheReadingField {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 8;
+  width: min(34rem, 72%);
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(90deg, rgb(25 23 20 / 0.88) 0%, rgb(25 23 20 / 0.56) 58%, transparent 100%);
+}
+
+.previewStrip {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background: #191714;
+}
+
+.previewStrip::before {
+  position: absolute;
+  inset: -18%;
+  z-index: -1;
+  content: "";
+  opacity: 0.78;
+  filter: blur(0.7px);
+  mix-blend-mode: screen;
+  transform: rotate(-5deg);
+}
+
+.stripInkBone::before {
+  background:
+    radial-gradient(ellipse at 22% 74%, rgb(245 238 222 / 0.18), transparent 38%),
+    radial-gradient(ellipse at 74% 32%, rgb(156 116 80 / 0.22), transparent 34%),
+    repeating-linear-gradient(104deg, transparent 0 16px, rgb(245 238 222 / 0.14) 17px 20px, transparent 22px 45px);
+}
+
+.stripMineral::before {
+  background:
+    radial-gradient(ellipse at 24% 72%, rgb(66 83 79 / 0.5), transparent 38%),
+    radial-gradient(ellipse at 74% 32%, rgb(75 89 121 / 0.42), transparent 34%),
+    repeating-linear-gradient(104deg, transparent 0 16px, rgb(157 175 197 / 0.16) 17px 20px, transparent 22px 45px);
+}
+
+.stripSienna::before {
+  background:
+    radial-gradient(ellipse at 24% 74%, rgb(126 69 61 / 0.52), transparent 38%),
+    radial-gradient(ellipse at 76% 32%, rgb(183 127 82 / 0.42), transparent 34%),
+    repeating-linear-gradient(104deg, transparent 0 16px, rgb(245 238 222 / 0.14) 17px 20px, transparent 22px 45px);
+}
+
+.stripViolet::before {
+  background:
+    radial-gradient(ellipse at 24% 74%, rgb(109 83 98 / 0.52), transparent 38%),
+    radial-gradient(ellipse at 76% 32%, rgb(154 107 112 / 0.34), transparent 34%),
+    repeating-linear-gradient(104deg, transparent 0 16px, rgb(185 172 201 / 0.16) 17px 20px, transparent 22px 45px);
 }

--- a/src/app/test/color/color.module.css
+++ b/src/app/test/color/color.module.css
@@ -1,0 +1,77 @@
+.surface {
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 78% 12%, rgb(119 101 78 / 0.16), transparent 25%),
+    radial-gradient(circle at 10% 88%, rgb(126 69 61 / 0.12), transparent 27%),
+    linear-gradient(145deg, #191714 0%, #12110f 48%, #211d18 100%);
+}
+
+.surface::before {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  content: "";
+  opacity: 0.2;
+  background:
+    repeating-linear-gradient(
+      108deg,
+      rgb(245 238 222 / 0.07) 0 1px,
+      transparent 1px 15px
+    ),
+    repeating-linear-gradient(
+      21deg,
+      rgb(0 0 0 / 0.26) 0 1px,
+      transparent 1px 19px
+    );
+  mix-blend-mode: soft-light;
+}
+
+.brushField {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(ellipse at 24% 68%, rgb(126 69 61 / 0.34), transparent 36%),
+    radial-gradient(ellipse at 66% 22%, rgb(66 83 79 / 0.34), transparent 34%),
+    linear-gradient(145deg, rgb(245 238 222 / 0.055), rgb(255 255 255 / 0.015)),
+    #191714;
+}
+
+.brushField::before {
+  position: absolute;
+  inset: -16%;
+  z-index: -1;
+  content: "";
+  opacity: 0.58;
+  background:
+    radial-gradient(ellipse at 18% 68%, rgb(183 127 82 / 0.28), transparent 36%),
+    radial-gradient(ellipse at 58% 46%, rgb(75 89 121 / 0.26), transparent 42%),
+    repeating-linear-gradient(106deg, transparent 0 17px, rgb(245 238 222 / 0.11) 18px 21px, transparent 23px 49px);
+  filter: blur(0.6px);
+  mix-blend-mode: screen;
+  transform: rotate(-5deg);
+}
+
+.paperStrip {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    linear-gradient(90deg, rgb(245 238 222 / 0.92), rgb(215 198 163 / 0.78)),
+    #f5eede;
+}
+
+.paperStrip::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+  opacity: 0.34;
+  background:
+    repeating-linear-gradient(
+      96deg,
+      rgb(25 23 20 / 0.1) 0 1px,
+      transparent 1px 13px
+    );
+  mix-blend-mode: multiply;
+}

--- a/src/app/test/color/color.module.css
+++ b/src/app/test/color/color.module.css
@@ -86,6 +86,67 @@
   -webkit-background-clip: text;
 }
 
+.highlightBrushText {
+  position: relative;
+  isolation: isolate;
+  width: fit-content;
+}
+
+.highlightBrushText .gradientText {
+  position: relative;
+  z-index: 3;
+}
+
+.highlightPaintLayer {
+  position: absolute;
+  left: -0.03em;
+  right: -0.03em;
+  top: 43%;
+  z-index: 1;
+  height: 0.44em;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-50%) rotate(-1.2deg);
+  will-change: opacity, transform;
+}
+
+.highlightPaintSvg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  filter: url("#color-gouache-bristle") drop-shadow(0 0 18px rgb(162 173 179 / 0.18));
+  mix-blend-mode: screen;
+}
+
+.highlightPaintBody,
+.highlightPaintBodyLight,
+.highlightPaintDry {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.highlightPaintBody {
+  stroke: rgb(162 173 179 / 0.58);
+  stroke-width: 8.5;
+}
+
+.highlightPaintBodyLight {
+  stroke: rgb(248 251 251 / 0.34);
+  stroke-width: 3.8;
+}
+
+.highlightPaintDry {
+  stroke: rgb(248 251 251 / 0.28);
+  stroke-dasharray: 10 9 2 13;
+  stroke-width: 1.5;
+}
+
+.highlightPaintFleck {
+  fill: rgb(248 251 251 / 0.44);
+}
+
 .gradientColdPearl {
   background-image: linear-gradient(
     112deg,

--- a/src/app/test/color/color.module.css
+++ b/src/app/test/color/color.module.css
@@ -1,9 +1,9 @@
 .surface {
   isolation: isolate;
   background:
-    radial-gradient(circle at 78% 12%, rgb(119 101 78 / 0.16), transparent 25%),
-    radial-gradient(circle at 10% 88%, rgb(126 69 61 / 0.12), transparent 27%),
-    linear-gradient(145deg, #191714 0%, #12110f 48%, #211d18 100%);
+    radial-gradient(circle at 78% 12%, rgb(31 42 40 / 0.12), transparent 25%),
+    radial-gradient(circle at 10% 88%, rgb(32 38 50 / 0.1), transparent 27%),
+    linear-gradient(145deg, #070707 0%, #030404 48%, #0c0d0c 100%);
 }
 
 .surface::before {
@@ -12,17 +12,17 @@
   z-index: 1;
   pointer-events: none;
   content: "";
-  opacity: 0.2;
+  opacity: 0.18;
   background:
     repeating-linear-gradient(
       108deg,
-      rgb(245 238 222 / 0.07) 0 1px,
-      transparent 1px 15px
+      rgb(232 236 236 / 0.026) 0 1px,
+      transparent 1px 18px
     ),
     repeating-linear-gradient(
       21deg,
-      rgb(0 0 0 / 0.26) 0 1px,
-      transparent 1px 19px
+      rgb(0 0 0 / 0.3) 0 1px,
+      transparent 1px 21px
     );
   mix-blend-mode: soft-light;
 }
@@ -32,10 +32,10 @@
   overflow: hidden;
   isolation: isolate;
   background:
-    radial-gradient(ellipse at 24% 68%, rgb(126 69 61 / 0.34), transparent 36%),
-    radial-gradient(ellipse at 66% 22%, rgb(66 83 79 / 0.34), transparent 34%),
-    linear-gradient(145deg, rgb(245 238 222 / 0.055), rgb(255 255 255 / 0.015)),
-    #191714;
+    radial-gradient(ellipse at 24% 68%, rgb(31 42 40 / 0.24), transparent 36%),
+    radial-gradient(ellipse at 66% 22%, rgb(32 38 50 / 0.2), transparent 34%),
+    linear-gradient(145deg, rgb(232 236 236 / 0.028), rgb(255 255 255 / 0.01)),
+    #070707;
 }
 
 .brushField::before {
@@ -43,76 +43,25 @@
   inset: -16%;
   z-index: -1;
   content: "";
-  opacity: 0.58;
+  opacity: 0.34;
   background:
-    radial-gradient(ellipse at 18% 68%, rgb(183 127 82 / 0.28), transparent 36%),
-    radial-gradient(ellipse at 58% 46%, rgb(75 89 121 / 0.26), transparent 42%),
-    repeating-linear-gradient(106deg, transparent 0 17px, rgb(245 238 222 / 0.11) 18px 21px, transparent 23px 49px);
+    radial-gradient(ellipse at 18% 68%, rgb(58 48 48 / 0.12), transparent 36%),
+    radial-gradient(ellipse at 58% 46%, rgb(32 38 50 / 0.18), transparent 42%),
+    linear-gradient(106deg, transparent 0 18%, rgb(232 236 236 / 0.055) 28%, transparent 46% 100%);
   filter: blur(0.6px);
   mix-blend-mode: screen;
   transform: rotate(-5deg);
 }
 
-.paperStrip {
-  position: relative;
-  overflow: hidden;
+.previewSurface {
   isolation: isolate;
+  --gouache-primary: 31 42 40;
+  --gouache-secondary: 32 38 50;
+  --gouache-light: 162 173 179;
+  --gouache-shadow: 2 3 3;
   background:
-    linear-gradient(90deg, rgb(245 238 222 / 0.92), rgb(215 198 163 / 0.78)),
-    #f5eede;
-}
-
-.paperStrip::before {
-  position: absolute;
-  inset: 0;
-  content: "";
-  opacity: 0.34;
-  background:
-    repeating-linear-gradient(
-      96deg,
-      rgb(25 23 20 / 0.1) 0 1px,
-      transparent 1px 13px
-  );
-  mix-blend-mode: multiply;
-}
-
-.candidateSurface {
-  isolation: isolate;
-  --gouache-primary: 245 238 222;
-  --gouache-secondary: 156 116 80;
-  --gouache-light: 245 238 222;
-  --gouache-shadow: 0 0 0;
-  background:
-    linear-gradient(145deg, rgb(245 238 222 / 0.045), rgb(255 255 255 / 0.015)),
-    #191714;
-}
-
-.candidateInkBone {
-  --gouache-primary: 156 116 80;
-  --gouache-secondary: 58 50 42;
-  --gouache-light: 245 238 222;
-  --gouache-shadow: 0 0 0;
-}
-
-.candidateMineral {
-  --gouache-primary: 66 83 79;
-  --gouache-secondary: 75 89 121;
-  --gouache-light: 157 175 197;
-  --gouache-shadow: 4 8 8;
-}
-
-.candidateSienna {
-  --gouache-primary: 126 69 61;
-  --gouache-secondary: 183 127 82;
-  --gouache-light: 245 238 222;
-  --gouache-shadow: 16 8 5;
-}
-
-.candidateViolet {
-  --gouache-primary: 109 83 98;
-  --gouache-secondary: 154 107 112;
-  --gouache-light: 185 172 201;
-  --gouache-shadow: 8 5 10;
+    linear-gradient(145deg, rgb(232 236 236 / 0.028), rgb(255 255 255 / 0.01)),
+    #070707;
 }
 
 .gouacheLayer {
@@ -133,81 +82,81 @@
 
 .gouacheLayer::before {
   z-index: 1;
-  opacity: 0.28;
+  opacity: 0.22;
   background:
     repeating-linear-gradient(
       108deg,
-      rgb(var(--gouache-light) / 0.08) 0 1px,
-      transparent 1px 13px
+      rgb(var(--gouache-light) / 0.05) 0 1px,
+      transparent 1px 18px
     ),
     repeating-linear-gradient(
       18deg,
-      rgb(0 0 0 / 0.28) 0 1px,
-      transparent 1px 17px
+      rgb(0 0 0 / 0.3) 0 1px,
+      transparent 1px 21px
     );
-  filter: url("#color-gouache-paper") contrast(1.18);
+  filter: url("#color-gouache-paper") contrast(1.08);
   mix-blend-mode: soft-light;
 }
 
 .gouacheLayer::after {
   z-index: 2;
-  opacity: 0.2;
+  opacity: 0.12;
   background:
-    radial-gradient(circle at 18% 42%, rgb(var(--gouache-light) / 0.22) 0 1px, transparent 1px 5px),
-    radial-gradient(circle at 78% 18%, rgb(var(--gouache-secondary) / 0.18) 0 1px, transparent 1px 6px);
+    radial-gradient(circle at 18% 42%, rgb(var(--gouache-light) / 0.1) 0 1px, transparent 1px 6px),
+    radial-gradient(circle at 78% 18%, rgb(var(--gouache-secondary) / 0.1) 0 1px, transparent 1px 7px);
   background-size:
-    10px 10px,
-    15px 15px;
+    12px 12px,
+    17px 17px;
   mix-blend-mode: screen;
 }
 
 .gouacheTexture {
   position: absolute;
   pointer-events: none;
-  filter: url("#color-gouache-bristle") blur(0.4px);
+  filter: url("#color-gouache-bristle") blur(0.5px);
   transform-origin: center;
 }
 
 .gouacheShadow {
-  left: -20%;
-  bottom: -40%;
+  left: -24%;
+  bottom: -42%;
   z-index: 3;
-  width: 68%;
-  height: 58%;
-  opacity: 0.5;
+  width: 72%;
+  height: 62%;
+  opacity: 0.62;
   background:
-    radial-gradient(ellipse at 38% 50%, rgb(var(--gouache-shadow) / 0.78) 0 22%, rgb(var(--gouache-primary) / 0.1) 44%, transparent 72%),
-    conic-gradient(from 224deg at 52% 54%, transparent 0 20%, rgb(var(--gouache-secondary) / 0.16) 28% 38%, transparent 48% 100%);
+    radial-gradient(ellipse at 38% 50%, rgb(var(--gouache-shadow) / 0.86) 0 24%, rgb(18 20 19 / 0.2) 46%, transparent 74%),
+    conic-gradient(from 224deg at 52% 54%, transparent 0 22%, rgb(var(--gouache-primary) / 0.12) 30% 38%, transparent 48% 100%);
   border-radius: 54% 42% 56% 38%;
   mix-blend-mode: multiply;
   transform: rotate(-10deg) skewX(-6deg);
 }
 
 .gouachePrimary {
-  right: -22%;
-  top: -20%;
+  right: -24%;
+  top: -18%;
   z-index: 4;
-  width: 60%;
-  height: 70%;
-  opacity: 0.56;
+  width: 62%;
+  height: 72%;
+  opacity: 0.16;
   background:
-    radial-gradient(ellipse at 42% 48%, rgb(var(--gouache-primary) / 0.58) 0 13%, rgb(var(--gouache-secondary) / 0.28) 30%, transparent 64%),
-    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(var(--gouache-light) / 0.2) 24% 31%, rgb(var(--gouache-primary) / 0.26) 38% 48%, transparent 58% 100%);
+    radial-gradient(ellipse at 42% 48%, rgb(var(--gouache-light) / 0.18) 0 13%, rgb(var(--gouache-primary) / 0.16) 32%, transparent 66%),
+    conic-gradient(from 218deg at 44% 48%, transparent 0 20%, rgb(var(--gouache-secondary) / 0.18) 26% 33%, rgb(var(--gouache-light) / 0.1) 40% 48%, transparent 58% 100%);
   border-radius: 44% 58% 40% 54%;
   mix-blend-mode: screen;
   transform: rotate(15deg) skewX(4deg);
 }
 
 .gouacheSecondary {
-  left: -12%;
+  left: -14%;
   top: 4%;
   z-index: 5;
   width: 62%;
   height: 72%;
-  opacity: 0.4;
+  opacity: 0.14;
   background:
-    linear-gradient(62deg, transparent 0 13%, rgb(var(--gouache-secondary) / 0.58) 27%, rgb(var(--gouache-primary) / 0.26) 49%, transparent 73%),
-    radial-gradient(ellipse at 38% 46%, rgb(var(--gouache-light) / 0.13) 0 16%, transparent 45%);
+    linear-gradient(62deg, transparent 0 13%, rgb(var(--gouache-secondary) / 0.28) 27%, rgb(var(--gouache-primary) / 0.14) 49%, transparent 73%),
+    radial-gradient(ellipse at 38% 46%, rgb(var(--gouache-light) / 0.06) 0 16%, transparent 45%);
   border-radius: 58% 42% 54% 38%;
   mix-blend-mode: screen;
   transform: rotate(-18deg) skewY(7deg);
@@ -219,16 +168,10 @@
   z-index: 6;
   width: 50%;
   height: 86%;
-  opacity: 0.24;
+  opacity: 0.11;
   background:
-    radial-gradient(ellipse at 42% 38%, rgb(var(--gouache-light) / 0.46) 0 12%, rgb(var(--gouache-light) / 0.2) 30%, transparent 62%),
-    conic-gradient(from 194deg at 52% 48%, transparent 0 18%, rgb(var(--gouache-light) / 0.22) 23% 31%, transparent 39% 100%),
-    repeating-linear-gradient(
-      103deg,
-      transparent 0 15px,
-      rgb(var(--gouache-light) / 0.16) 17px 20px,
-      transparent 23px 44px
-    );
+    radial-gradient(ellipse at 42% 38%, rgb(var(--gouache-light) / 0.22) 0 12%, rgb(var(--gouache-light) / 0.1) 30%, transparent 62%),
+    conic-gradient(from 194deg at 52% 48%, transparent 0 18%, rgb(var(--gouache-light) / 0.12) 23% 31%, transparent 39% 100%);
   border-radius: 44% 58% 38% 54%;
   mix-blend-mode: screen;
   transform: rotate(14deg) skewY(-6deg);
@@ -236,19 +179,19 @@
 
 .gouacheDryLine {
   position: absolute;
-  right: -8%;
+  right: -10%;
   top: 0;
   z-index: 7;
   width: 44%;
   height: 100%;
   pointer-events: none;
-  opacity: 0.18;
+  opacity: 0.05;
   background:
     repeating-linear-gradient(
       103deg,
-      transparent 0 20px,
-      rgb(var(--gouache-light) / 0.22) 22px 24px,
-      transparent 26px 54px
+      transparent 0 26px,
+      rgb(var(--gouache-light) / 0.18) 28px 30px,
+      transparent 32px 72px
     );
   filter: url("#color-gouache-bristle") blur(1px);
   mix-blend-mode: screen;
@@ -263,14 +206,14 @@
   width: min(34rem, 72%);
   height: 100%;
   pointer-events: none;
-  background: linear-gradient(90deg, rgb(25 23 20 / 0.88) 0%, rgb(25 23 20 / 0.56) 58%, transparent 100%);
+  background: linear-gradient(90deg, rgb(7 7 7 / 0.9) 0%, rgb(7 7 7 / 0.62) 58%, transparent 100%);
 }
 
 .previewStrip {
   position: relative;
   overflow: hidden;
   isolation: isolate;
-  background: #191714;
+  background: #070707;
 }
 
 .previewStrip::before {
@@ -278,36 +221,36 @@
   inset: -18%;
   z-index: -1;
   content: "";
-  opacity: 0.78;
+  opacity: 0.56;
+  background:
+    radial-gradient(ellipse at 24% 72%, rgb(31 42 40 / 0.42), transparent 38%),
+    radial-gradient(ellipse at 74% 32%, rgb(32 38 50 / 0.34), transparent 36%),
+    linear-gradient(104deg, transparent 0 18%, rgb(162 173 179 / 0.07) 27%, transparent 43% 100%);
   filter: blur(0.7px);
   mix-blend-mode: screen;
   transform: rotate(-5deg);
 }
 
-.stripInkBone::before {
+.graphiteStrip {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
   background:
-    radial-gradient(ellipse at 22% 74%, rgb(245 238 222 / 0.18), transparent 38%),
-    radial-gradient(ellipse at 74% 32%, rgb(156 116 80 / 0.22), transparent 34%),
-    repeating-linear-gradient(104deg, transparent 0 16px, rgb(245 238 222 / 0.14) 17px 20px, transparent 22px 45px);
+    radial-gradient(ellipse at 24% 72%, rgb(31 42 40 / 0.36), transparent 38%),
+    radial-gradient(ellipse at 74% 32%, rgb(32 38 50 / 0.28), transparent 36%),
+    linear-gradient(145deg, #101211, #070707);
 }
 
-.stripMineral::before {
+.graphiteStrip::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+  opacity: 0.24;
   background:
-    radial-gradient(ellipse at 24% 72%, rgb(66 83 79 / 0.5), transparent 38%),
-    radial-gradient(ellipse at 74% 32%, rgb(75 89 121 / 0.42), transparent 34%),
-    repeating-linear-gradient(104deg, transparent 0 16px, rgb(157 175 197 / 0.16) 17px 20px, transparent 22px 45px);
-}
-
-.stripSienna::before {
-  background:
-    radial-gradient(ellipse at 24% 74%, rgb(126 69 61 / 0.52), transparent 38%),
-    radial-gradient(ellipse at 76% 32%, rgb(183 127 82 / 0.42), transparent 34%),
-    repeating-linear-gradient(104deg, transparent 0 16px, rgb(245 238 222 / 0.14) 17px 20px, transparent 22px 45px);
-}
-
-.stripViolet::before {
-  background:
-    radial-gradient(ellipse at 24% 74%, rgb(109 83 98 / 0.52), transparent 38%),
-    radial-gradient(ellipse at 76% 32%, rgb(154 107 112 / 0.34), transparent 34%),
-    repeating-linear-gradient(104deg, transparent 0 16px, rgb(185 172 201 / 0.16) 17px 20px, transparent 22px 45px);
+    repeating-linear-gradient(
+      96deg,
+      rgb(232 236 236 / 0.04) 0 1px,
+      transparent 1px 16px
+    );
+  mix-blend-mode: soft-light;
 }

--- a/src/app/test/color/highlight-brush-text.tsx
+++ b/src/app/test/color/highlight-brush-text.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { editorialEase } from "@/constant/motion-preset";
+import { cn } from "@/utils/tailwind-util";
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import styles from "./color.module.css";
+
+interface HighlightBrushTextProps {
+  as: "h1" | "h3";
+  children: ReactNode;
+  className?: string;
+  textClassName?: string;
+}
+
+const brushLayerPreset = {
+  rest: {
+    opacity: 0,
+  },
+  hover: {
+    opacity: [0, 1, 0.82],
+    transition: {
+      duration: 0.92,
+      ease: editorialEase,
+      times: [0, 0.18, 1],
+    },
+  },
+};
+
+const brushBodyPreset = {
+  rest: {
+    pathLength: 0,
+    opacity: 0,
+  },
+  hover: {
+    pathLength: [0, 1, 1],
+    opacity: [0, 0.74, 0.46],
+    transition: {
+      duration: 0.86,
+      ease: editorialEase,
+      times: [0, 0.68, 1],
+    },
+  },
+};
+
+const brushDryPreset = {
+  rest: {
+    pathLength: 0,
+    opacity: 0,
+  },
+  hover: {
+    pathLength: [0, 1, 1],
+    opacity: [0, 0.64, 0.28],
+    transition: {
+      delay: 0.08,
+      duration: 0.74,
+      ease: editorialEase,
+      times: [0, 0.74, 1],
+    },
+  },
+};
+
+const brushFleckPreset = {
+  rest: {
+    opacity: 0,
+    scale: 0.4,
+  },
+  hover: {
+    opacity: [0, 0.58, 0.18],
+    scale: [0.4, 1, 0.74],
+    transition: {
+      delay: 0.34,
+      duration: 0.46,
+      ease: editorialEase,
+      times: [0, 0.48, 1],
+    },
+  },
+};
+
+const HighlightBrushPaint = () => {
+  return (
+    <motion.span
+      aria-hidden="true"
+      className={cn(styles.highlightPaintLayer, "motion-reduce:hidden")}
+      variants={brushLayerPreset}
+    >
+      <svg
+        className={styles.highlightPaintSvg}
+        focusable="false"
+        preserveAspectRatio="none"
+        viewBox="0 0 100 24"
+      >
+        <motion.path
+          className={styles.highlightPaintBody}
+          d="M2 15 C13 8 24 18 34 13 C47 6 58 17 70 12 C82 7 91 13 98 8"
+          variants={brushBodyPreset}
+        />
+        <motion.path
+          className={styles.highlightPaintBodyLight}
+          d="M3 13 C18 9 25 16 39 11 C52 7 62 14 75 10 C86 7 94 11 99 9"
+          variants={brushBodyPreset}
+        />
+        <motion.path
+          className={styles.highlightPaintDry}
+          d="M1 18 C18 18 26 14 42 17 C55 19 66 12 82 15 C90 16 95 13 99 14"
+          variants={brushDryPreset}
+        />
+        <motion.path
+          className={styles.highlightPaintDry}
+          d="M4 9 C17 12 29 7 43 10 C57 13 68 8 84 10 C91 11 96 9 99 10"
+          variants={brushDryPreset}
+        />
+        <motion.circle
+          className={styles.highlightPaintFleck}
+          cx="18"
+          cy="7"
+          r="0.9"
+          variants={brushFleckPreset}
+        />
+        <motion.circle
+          className={styles.highlightPaintFleck}
+          cx="46"
+          cy="18"
+          r="0.75"
+          variants={brushFleckPreset}
+        />
+        <motion.circle
+          className={styles.highlightPaintFleck}
+          cx="82"
+          cy="6"
+          r="0.7"
+          variants={brushFleckPreset}
+        />
+      </svg>
+    </motion.span>
+  );
+};
+
+const HighlightBrushContent = ({
+  children,
+  textClassName,
+}: Pick<HighlightBrushTextProps, "children" | "textClassName">) => {
+  return (
+    <>
+      <HighlightBrushPaint />
+      <span className={cn(styles.gradientText, textClassName)}>{children}</span>
+    </>
+  );
+};
+
+const HighlightBrushText = ({
+  as,
+  children,
+  className,
+  textClassName,
+}: HighlightBrushTextProps) => {
+  if (as === "h1") {
+    return (
+      <motion.h1
+        animate="rest"
+        className={cn(styles.highlightBrushText, className)}
+        initial="rest"
+        whileHover="hover"
+      >
+        <HighlightBrushContent textClassName={textClassName}>
+          {children}
+        </HighlightBrushContent>
+      </motion.h1>
+    );
+  }
+
+  return (
+    <motion.h3
+      animate="rest"
+      className={cn(styles.highlightBrushText, className)}
+      initial="rest"
+      whileHover="hover"
+    >
+      <HighlightBrushContent textClassName={textClassName}>
+        {children}
+      </HighlightBrushContent>
+    </motion.h3>
+  );
+};
+
+export { HighlightBrushText };

--- a/src/app/test/color/page.tsx
+++ b/src/app/test/color/page.tsx
@@ -4,195 +4,68 @@ import styles from "./color.module.css";
 
 export const metadata: Metadata = {
   title: "Color Test | ou9999.dev",
-  description: "Analog gouache color test page",
+  description: "Mineral Wash color reference page",
 };
 
 interface ColorChip {
   name: string;
   value: string;
   className: string;
+  usage: string;
   textClassName?: string;
 }
 
-interface PaletteGroup {
-  title: string;
-  note: string;
-  colors: ColorChip[];
-}
-
-interface Candidate {
-  eyebrow: string;
-  title: string;
-  note: string;
-  surfaceClassName: string;
-  stripClassName: string;
-  colors: ColorChip[];
-}
-
-const baseColors: ColorChip[] = [
+const mineralWashColors: ColorChip[] = [
   {
-    name: "ink black",
-    value: "#191714",
-    className: "bg-[#191714]",
+    name: "soot",
+    value: "#020303",
+    className: "bg-[#020303]",
+    usage: "deepest shadow",
   },
   {
-    name: "bone white",
-    value: "#F5EEDE",
-    className: "bg-[#F5EEDE]",
-    textClassName: "text-[#191714]",
+    name: "graphite black",
+    value: "#070707",
+    className: "bg-[#070707]",
+    usage: "page base",
   },
   {
-    name: "paper ash",
-    value: "#AFA89A",
-    className: "bg-[#AFA89A]",
-    textClassName: "text-[#191714]",
-  },
-];
-
-const paletteGroups: PaletteGroup[] = [
-  {
-    title: "Mineral",
-    note: "차갑지만 네온으로 가지 않는 개발 블로그용 보조색",
-    colors: [
-      {
-        name: "oxide teal",
-        value: "#42534F",
-        className: "bg-[#42534F]",
-      },
-      {
-        name: "slate indigo",
-        value: "#4B5979",
-        className: "bg-[#4B5979]",
-      },
-      {
-        name: "dried moss",
-        value: "#626449",
-        className: "bg-[#626449]",
-      },
-    ],
+    name: "graphite surface",
+    value: "#101211",
+    className: "bg-[#101211]",
+    usage: "header, framed surface",
   },
   {
-    title: "Earth",
-    note: "붓질과 종이 질감을 살리는 낮은 채도의 따뜻한 안료",
-    colors: [
-      {
-        name: "burnt sienna",
-        value: "#7E453D",
-        className: "bg-[#7E453D]",
-      },
-      {
-        name: "raw ochre",
-        value: "#B77F52",
-        className: "bg-[#B77F52]",
-      },
-      {
-        name: "mud violet",
-        value: "#6D5362",
-        className: "bg-[#6D5362]",
-      },
-    ],
-  },
-];
-
-const candidates: Candidate[] = [
-  {
-    eyebrow: "candidate 01",
-    title: "Ink Bone Minimal",
-    note: "본문 가독성을 최우선으로 두고, 붓질은 섹션 전환과 썸네일 표면에만 남기는 가장 조용한 후보",
-    surfaceClassName: styles.candidateInkBone,
-    stripClassName: styles.stripInkBone,
-    colors: [
-      baseColors[0],
-      baseColors[1],
-      {
-        name: "smoke umber",
-        value: "#3A322A",
-        className: "bg-[#3A322A]",
-      },
-      {
-        name: "soft ochre",
-        value: "#9C7450",
-        className: "bg-[#9C7450]",
-      },
-    ],
+    name: "mineral teal",
+    value: "#1F2A28",
+    className: "bg-[#1F2A28]",
+    usage: "gouache wash shadow",
   },
   {
-    eyebrow: "candidate 02",
-    title: "Mineral Wash",
-    note: "검은 바탕 위에 산화 청록과 남색을 얇게 올린 후보. 차갑지만 AI 네온처럼 보이지 않게 낮은 채도로 제한",
-    surfaceClassName: styles.candidateMineral,
-    stripClassName: styles.stripMineral,
-    colors: [
-      baseColors[0],
-      {
-        name: "oxide teal",
-        value: "#42534F",
-        className: "bg-[#42534F]",
-      },
-      {
-        name: "slate indigo",
-        value: "#4B5979",
-        className: "bg-[#4B5979]",
-      },
-      {
-        name: "chalk blue",
-        value: "#9DAFC5",
-        className: "bg-[#9DAFC5]",
-        textClassName: "text-[#191714]",
-      },
-    ],
+    name: "slate mineral",
+    value: "#202632",
+    className: "bg-[#202632]",
+    usage: "cool wash depth",
   },
   {
-    eyebrow: "candidate 03",
-    title: "Sienna Archive",
-    note: "아날로그 붓질의 따뜻함을 가장 직접적으로 드러내는 후보. 썸네일 시스템과 잘 맞는지 확인 필요",
-    surfaceClassName: styles.candidateSienna,
-    stripClassName: styles.stripSienna,
-    colors: [
-      baseColors[0],
-      {
-        name: "burnt sienna",
-        value: "#7E453D",
-        className: "bg-[#7E453D]",
-      },
-      {
-        name: "raw ochre",
-        value: "#B77F52",
-        className: "bg-[#B77F52]",
-      },
-      {
-        name: "paper ash",
-        value: "#AFA89A",
-        className: "bg-[#AFA89A]",
-        textClassName: "text-[#191714]",
-      },
-    ],
+    name: "cool ash",
+    value: "#8B9290",
+    className: "bg-[#8B9290]",
+    usage: "secondary text",
+    textClassName: "text-[#020303]",
   },
   {
-    eyebrow: "candidate 04",
-    title: "Night Violet",
-    note: "감성은 가장 강하지만 본문 전체에 쓰기엔 위험한 후보. 강조 장면이나 대표 이미지용으로 비교",
-    surfaceClassName: styles.candidateViolet,
-    stripClassName: styles.stripViolet,
-    colors: [
-      baseColors[0],
-      {
-        name: "mud violet",
-        value: "#6D5362",
-        className: "bg-[#6D5362]",
-      },
-      {
-        name: "dust rose",
-        value: "#9A6B70",
-        className: "bg-[#9A6B70]",
-      },
-      {
-        name: "lavender ash",
-        value: "#B9ACC9",
-        className: "bg-[#B9ACC9]",
-        textClassName: "text-[#191714]",
-      },
-    ],
+    name: "chalk blue",
+    value: "#A2ADB3",
+    className: "bg-[#A2ADB3]",
+    usage: "links, thin border",
+    textClassName: "text-[#020303]",
+  },
+  {
+    name: "cold paper",
+    value: "#E8ECEC",
+    className: "bg-[#E8ECEC]",
+    usage: "primary text",
+    textClassName: "text-[#020303]",
   },
 ];
 
@@ -200,12 +73,17 @@ const ColorChipCard = ({ color }: { color: ColorChip }) => {
   return (
     <article
       className={cn(
-        "flex min-h-32 flex-col justify-between border-1 border-white/14 p-4 text-google-paper",
+        "flex min-h-40 flex-col justify-between border-1 border-mineral-blue/18 p-4 text-google-paper",
         color.className,
         color.textClassName
       )}
     >
-      <p className="text-lg font-semibold">{color.name}</p>
+      <div>
+        <p className="text-lg font-semibold">{color.name}</p>
+        <p className="mt-2 max-w-[220px] break-keep text-sm leading-5 opacity-72">
+          {color.usage}
+        </p>
+      </div>
       <p className="font-mono text-sm uppercase opacity-72">{color.value}</p>
     </article>
   );
@@ -230,7 +108,7 @@ const ColorGouacheFilters = () => {
           in="noise"
           result="paper"
           type="matrix"
-          values="0.35 0 0 0 0.58 0 0.35 0 0 0.58 0 0 0.35 0 0.58 0 0 0 0.24 0"
+          values="0.35 0 0 0 0.5 0 0.35 0 0 0.5 0 0 0.35 0 0.5 0 0 0 0.2 0"
         />
         <feBlend in="SourceGraphic" in2="paper" mode="multiply" />
       </filter>
@@ -251,7 +129,7 @@ const ColorGouacheFilters = () => {
         />
         <feColorMatrix
           type="matrix"
-          values="1.08 0 0 0 -0.02 0 1.08 0 0 -0.02 0 0 1.08 0 -0.02 0 0 0 1 0"
+          values="1.05 0 0 0 -0.02 0 1.05 0 0 -0.02 0 0 1.05 0 -0.02 0 0 0 1 0"
         />
       </filter>
     </svg>
@@ -268,61 +146,6 @@ const GouacheLayer = () => {
       <div className={styles.gouacheDryLine} />
       <div className={styles.gouacheReadingField} />
     </div>
-  );
-};
-
-const CandidatePreview = ({ candidate }: { candidate: Candidate }) => {
-  return (
-    <article
-      className={cn(
-        "relative min-h-[520px] overflow-hidden border-1 border-white/14 p-5 text-google-paper md:p-6",
-        styles.candidateSurface,
-        candidate.surfaceClassName
-      )}
-    >
-      <GouacheLayer />
-      <div className="relative z-10 flex min-h-[472px] flex-col">
-        <p className="text-sm font-semibold uppercase text-google-paper/50">
-          {candidate.eyebrow}
-        </p>
-        <h3 className="mt-6 max-w-[520px] break-keep text-4xl font-normal leading-tight md:text-5xl">
-          {candidate.title}
-        </h3>
-        <p className="mt-5 max-w-[560px] break-keep text-sm leading-6 text-google-paper/64 md:text-base md:leading-7">
-          {candidate.note}
-        </p>
-
-        <div
-          className={cn(
-            "mt-auto min-h-36 border-1 border-white/12 p-4",
-            styles.previewStrip,
-            candidate.stripClassName
-          )}
-        >
-          <p className="max-w-[360px] break-keep text-2xl font-semibold leading-tight">
-            글 표면은 조용하게, 이미지는 손으로 칠한 듯하게
-          </p>
-        </div>
-
-        <div className="mt-5 grid grid-cols-2 gap-2 md:grid-cols-4">
-          {candidate.colors.map((color) => (
-            <div
-              className={cn(
-                "flex min-h-20 flex-col justify-between border-1 border-white/14 p-3 text-xs text-google-paper",
-                color.className,
-                color.textClassName
-              )}
-              key={color.name}
-            >
-              <span className="font-semibold">{color.name}</span>
-              <span className="font-mono uppercase opacity-72">
-                {color.value}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </article>
   );
 };
 
@@ -343,99 +166,76 @@ const ColorPage = () => {
                 /test/color
               </p>
               <h1 className="mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]">
-                아날로그 붓질을 위한 컬러
+                Mineral Wash
               </h1>
               <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
-                자개 팔레트는 보존하고, 블로그 본문에는 구아슈의 손맛을 더
-                잘 살리는 저채도 컬러를 따로 탐색합니다. 배경은 조용하게,
-                색은 썸네일과 강조 표면에서 먼저 검증합니다.
+                블로그에서 사용할 최종 컬러만 남긴 기준표입니다. 색 변화는
+                거의 검은 graphite 안에서 움직이고, 구아슈 느낌은 viewport를
+                따라다니는 fixed 레이어와 얇은 표면 질감에서만 드러냅니다.
               </p>
             </div>
 
-            <aside className={cn("border-1 border-white/14 p-6", styles.brushField)}>
+            <aside className={cn("border-1 border-mineral-blue/18 p-6", styles.brushField)}>
               <p className="text-sm font-semibold uppercase text-google-paper/52">
-                direction
+                canonical direction
               </p>
               <p className="mt-16 max-w-[340px] break-keep text-3xl font-normal leading-tight">
-                black canvas, muted pigment, readable writing
+                black canvas, graphite wash, cold readable type
               </p>
             </aside>
           </div>
 
-          <div className="mt-16 grid gap-4 md:grid-cols-3">
-            {baseColors.map((color) => (
-              <ColorChipCard color={color} key={color.name} />
-            ))}
-          </div>
-
-          <div className="mt-16 grid gap-6 lg:grid-cols-2">
-            {paletteGroups.map((group) => (
-              <section
-                className="border-1 border-white/14 bg-white/[0.03] p-5"
-                key={group.title}
-              >
-                <div className="mb-5 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-                  <h2 className="text-3xl font-normal">{group.title}</h2>
-                  <p className="max-w-[320px] break-keep text-sm leading-6 text-google-paper/58">
-                    {group.note}
-                  </p>
-                </div>
-                <div className="grid gap-3 md:grid-cols-3">
-                  {group.colors.map((color) => (
-                    <ColorChipCard color={color} key={color.name} />
-                  ))}
-                </div>
-              </section>
-            ))}
-          </div>
-
-          <section className="mt-20">
-            <div className="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-              <div>
-                <p className="text-sm font-semibold uppercase text-google-paper/50">
-                  color + gouache candidates
-                </p>
-                <h2 className="mt-4 break-keep text-4xl font-normal leading-tight md:text-6xl">
-                  여러 후보를 같은 조건에서 비교
-                </h2>
-              </div>
+          <section className="mt-16">
+            <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <h2 className="text-4xl font-normal leading-tight md:text-6xl">
+                Palette
+              </h2>
               <p className="max-w-[520px] break-keep text-sm leading-6 text-google-paper/60 md:text-base md:leading-7">
-                `/test/color`의 저채도 팔레트와 `/test/gouache`의 붓질 레이어
-                감각을 섞은 후보입니다. 본문 가독성, 썸네일 개성, 블로그 톤을
-                같이 비교합니다.
+                이 페이지의 색만 현재 Mineral Wash 기준으로 사용합니다.
+                `/test/jagae`의 자개색과 이전 구아슈 후보는 보존용입니다.
               </p>
             </div>
-
-            <div className="grid gap-5 xl:grid-cols-2">
-              {candidates.map((candidate) => (
-                <CandidatePreview
-                  candidate={candidate}
-                  key={candidate.title}
-                />
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              {mineralWashColors.map((color) => (
+                <ColorChipCard color={color} key={color.name} />
               ))}
             </div>
           </section>
 
-          <section className="mt-16 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
-            <article className="border-1 border-white/14 bg-[#191714] p-6">
-              <p className="text-sm font-semibold uppercase text-google-paper/50">
-                readability sample
-              </p>
-              <h2 className="mt-12 max-w-[720px] break-keep text-5xl font-normal leading-tight md:text-6xl">
-                글을 읽는 표면은 끝까지 조용해야 한다
-              </h2>
-              <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72">
-                구아슈의 질감은 본문 뒤에 직접 깔지 않고, 제목 주변의 여백,
-                카드 이미지, 섹션 전환부에서만 낮은 농도로 드러냅니다.
-              </p>
+          <section className="mt-20 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+            <article
+              className={cn(
+                "relative min-h-[520px] overflow-hidden border-1 border-mineral-blue/18 p-6",
+                styles.previewSurface
+              )}
+            >
+              <GouacheLayer />
+              <div className="relative z-10 flex min-h-[472px] flex-col">
+                <p className="text-sm font-semibold uppercase text-google-paper/50">
+                  mineral wash + gouache layer
+                </p>
+                <h2 className="mt-10 max-w-[720px] break-keep text-5xl font-normal leading-tight md:text-7xl">
+                  거의 단색처럼 보이는 검은 붓질
+                </h2>
+                <p className="mt-8 max-w-[620px] break-keep text-base leading-7 text-google-paper/68 md:text-lg md:leading-8">
+                  색상은 밝게 튀지 않고, 구아슈 레이어의 입자와 가장자리
+                  흐림만 남깁니다. 실제 블로그에서는 이 레이어가 최상단
+                  layout의 fixed 배경으로 viewport를 따라다닙니다.
+                </p>
+                <div className={cn("mt-auto min-h-36 border-1 border-mineral-blue/14 p-4", styles.previewStrip)}>
+                  <p className="max-w-[420px] break-keep text-2xl font-semibold leading-tight">
+                    readable surface, low pigment, matte grain
+                  </p>
+                </div>
+              </div>
             </article>
 
-            <article className="border-1 border-white/14 bg-white/[0.03] p-5">
-              <div className={cn("h-32", styles.paperStrip)} />
-              <p className="mt-8 text-2xl font-semibold">thumbnail strip</p>
+            <article className="border-1 border-mineral-blue/18 bg-mineral-frame p-5">
+              <div className={cn("h-40", styles.graphiteStrip)} />
+              <p className="mt-8 text-2xl font-semibold">surface strip</p>
               <p className="mt-4 break-keep text-sm leading-6 text-google-paper/60">
-                밝은 종이색은 전체 배경이 아니라 썸네일 안에서만 제한적으로
-                사용합니다.
+                밝은 색은 본문 배경이 아니라 텍스트와 얇은 경계선에만
+                사용합니다. 표면 그라데이션은 black/graphite 범위로 제한합니다.
               </p>
             </article>
           </section>

--- a/src/app/test/color/page.tsx
+++ b/src/app/test/color/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { cn } from "@/utils/tailwind-util";
+import { HighlightBrushText } from "./highlight-brush-text";
 import styles from "./color.module.css";
 
 export const metadata: Metadata = {
@@ -61,10 +62,10 @@ const mineralWashColors: ColorChip[] = [
     textClassName: "text-[#020303]",
   },
   {
-    name: "chalk blue",
+    name: "blue steel",
     value: "#A2ADB3",
     className: "bg-[#A2ADB3]",
-    usage: "links, thin border",
+    usage: "links, highlight core",
     textClassName: "text-[#020303]",
   },
   {
@@ -85,7 +86,7 @@ const textGradientCandidates: TextGradientCandidate[] = [
   },
   {
     name: "Blue Steel",
-    tone: "cooler accent",
+    tone: "selected highlight",
     className: styles.gradientBlueSteel,
     intent: "링크와 포스트 제목에 쓸 때 가장 또렷하게 보이는 은청색 강조 후보입니다.",
   },
@@ -147,15 +148,13 @@ const TextGradientCandidateCard = ({
             <p className="text-sm font-semibold uppercase text-google-paper/52">
               {candidate.tone}
             </p>
-            <h3
-              className={cn(
-                "mt-4 break-keep text-5xl font-normal leading-none md:text-6xl",
-                styles.gradientText,
-                candidate.className
-              )}
+            <HighlightBrushText
+              as="h3"
+              className="mt-4 break-keep text-5xl font-normal leading-none md:text-6xl"
+              textClassName={candidate.className}
             >
               {candidate.name}
-            </h3>
+            </HighlightBrushText>
           </div>
           <span className="border-1 border-mineral-blue/18 px-3 py-1 text-xs font-semibold uppercase text-google-paper/58">
             text
@@ -260,15 +259,13 @@ const ColorPage = () => {
               <p className="text-sm font-semibold uppercase text-google-paper/56">
                 /test/color
               </p>
-              <h1
-                className={cn(
-                  "mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]",
-                  styles.gradientText,
-                  styles.gradientColdPearl
-                )}
+              <HighlightBrushText
+                as="h1"
+                className="mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]"
+                textClassName={styles.gradientBlueSteel}
               >
                 Mineral Wash
-              </h1>
+              </HighlightBrushText>
               <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
                 블로그에서 사용할 최종 컬러만 남긴 기준표입니다. 색 변화는
                 거의 검은 graphite 안에서 움직이고, 구아슈 느낌은 viewport를
@@ -309,9 +306,9 @@ const ColorPage = () => {
                 Text Gradient
               </h2>
               <p className="max-w-[560px] break-keep text-sm leading-6 text-google-paper/60 md:text-base md:leading-7">
-                하이라이트가 약해 보이는 문제를 보강하기 위한 후보입니다.
-                배경은 검게 유지하고, 강조 텍스트 안에서만 차가운 광택과 붓질
-                명도 차를 만듭니다.
+                Blue Steel을 실제 하이라이트 기준으로 선택했습니다. 배경은
+                검게 유지하고, 강조 텍스트 안에서만 차가운 광택과 붓질 명도
+                차를 만듭니다.
               </p>
             </div>
             <div className="grid gap-4 xl:grid-cols-2">

--- a/src/app/test/color/page.tsx
+++ b/src/app/test/color/page.tsx
@@ -15,6 +15,13 @@ interface ColorChip {
   textClassName?: string;
 }
 
+interface TextGradientCandidate {
+  name: string;
+  tone: string;
+  className: string;
+  intent: string;
+}
+
 const mineralWashColors: ColorChip[] = [
   {
     name: "soot",
@@ -69,6 +76,39 @@ const mineralWashColors: ColorChip[] = [
   },
 ];
 
+const textGradientCandidates: TextGradientCandidate[] = [
+  {
+    name: "Cold Pearl",
+    tone: "recommended baseline",
+    className: styles.gradientColdPearl,
+    intent: "현재 Mineral Wash의 차가운 흰 글자를 유지하면서 명도 차만 더 키운 기본 후보입니다.",
+  },
+  {
+    name: "Blue Steel",
+    tone: "cooler accent",
+    className: styles.gradientBlueSteel,
+    intent: "링크와 포스트 제목에 쓸 때 가장 또렷하게 보이는 은청색 강조 후보입니다.",
+  },
+  {
+    name: "Mineral Teal",
+    tone: "gouache aligned",
+    className: styles.gradientMineralTeal,
+    intent: "구아슈 레이어의 teal wash를 텍스트 쪽으로 조금 끌어올린 후보입니다.",
+  },
+  {
+    name: "Oxide Ash",
+    tone: "analog warmth",
+    className: styles.gradientOxideAsh,
+    intent: "노란 기운은 피하고, 붓칠의 아날로그 질감만 약간 따뜻하게 보강한 후보입니다.",
+  },
+  {
+    name: "Hard Chalk",
+    tone: "highest contrast",
+    className: styles.gradientHardChalk,
+    intent: "검은 배경 위에서 가장 강하게 튀는 후보입니다. 포인트가 약하다고 느낄 때 비교용입니다.",
+  },
+];
+
 const ColorChipCard = ({ color }: { color: ColorChip }) => {
   return (
     <article
@@ -85,6 +125,61 @@ const ColorChipCard = ({ color }: { color: ColorChip }) => {
         </p>
       </div>
       <p className="font-mono text-sm uppercase opacity-72">{color.value}</p>
+    </article>
+  );
+};
+
+const TextGradientCandidateCard = ({
+  candidate,
+}: {
+  candidate: TextGradientCandidate;
+}) => {
+  return (
+    <article
+      className={cn(
+        "relative overflow-hidden border-1 border-mineral-blue/18 bg-mineral-frame p-5",
+        styles.gradientCard
+      )}
+    >
+      <div className="relative z-10">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold uppercase text-google-paper/52">
+              {candidate.tone}
+            </p>
+            <h3
+              className={cn(
+                "mt-4 break-keep text-5xl font-normal leading-none md:text-6xl",
+                styles.gradientText,
+                candidate.className
+              )}
+            >
+              {candidate.name}
+            </h3>
+          </div>
+          <span className="border-1 border-mineral-blue/18 px-3 py-1 text-xs font-semibold uppercase text-google-paper/58">
+            text
+          </span>
+        </div>
+        <p className="mt-8 break-keep text-sm leading-6 text-google-paper/62">
+          {candidate.intent}
+        </p>
+        <div className="mt-8 grid gap-4 md:grid-cols-[1fr_0.78fr]">
+          <p
+            className={cn(
+              "break-keep text-3xl font-normal leading-tight",
+              styles.gradientText,
+              candidate.className
+            )}
+          >
+            조용한 검은 붓질 위의 강조 문장
+          </p>
+          <p className="break-keep text-base leading-7 text-google-paper/66">
+            일반 본문은 그대로 두고, 제목·링크·짧은 인용문 같은 순간에만
+            적용합니다.
+          </p>
+        </div>
+      </div>
     </article>
   );
 };
@@ -165,7 +260,13 @@ const ColorPage = () => {
               <p className="text-sm font-semibold uppercase text-google-paper/56">
                 /test/color
               </p>
-              <h1 className="mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]">
+              <h1
+                className={cn(
+                  "mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]",
+                  styles.gradientText,
+                  styles.gradientColdPearl
+                )}
+              >
                 Mineral Wash
               </h1>
               <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
@@ -198,6 +299,27 @@ const ColorPage = () => {
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               {mineralWashColors.map((color) => (
                 <ColorChipCard color={color} key={color.name} />
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-20">
+            <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <h2 className="text-4xl font-normal leading-tight md:text-6xl">
+                Text Gradient
+              </h2>
+              <p className="max-w-[560px] break-keep text-sm leading-6 text-google-paper/60 md:text-base md:leading-7">
+                하이라이트가 약해 보이는 문제를 보강하기 위한 후보입니다.
+                배경은 검게 유지하고, 강조 텍스트 안에서만 차가운 광택과 붓질
+                명도 차를 만듭니다.
+              </p>
+            </div>
+            <div className="grid gap-4 xl:grid-cols-2">
+              {textGradientCandidates.map((candidate) => (
+                <TextGradientCandidateCard
+                  candidate={candidate}
+                  key={candidate.name}
+                />
               ))}
             </div>
           </section>

--- a/src/app/test/color/page.tsx
+++ b/src/app/test/color/page.tsx
@@ -1,0 +1,194 @@
+import type { Metadata } from "next";
+import { cn } from "@/utils/tailwind-util";
+import styles from "./color.module.css";
+
+export const metadata: Metadata = {
+  title: "Color Test | ou9999.dev",
+  description: "Analog gouache color test page",
+};
+
+interface ColorChip {
+  name: string;
+  value: string;
+  className: string;
+  textClassName?: string;
+}
+
+interface PaletteGroup {
+  title: string;
+  note: string;
+  colors: ColorChip[];
+}
+
+const baseColors: ColorChip[] = [
+  {
+    name: "ink black",
+    value: "#191714",
+    className: "bg-[#191714]",
+  },
+  {
+    name: "bone white",
+    value: "#F5EEDE",
+    className: "bg-[#F5EEDE]",
+    textClassName: "text-[#191714]",
+  },
+  {
+    name: "paper ash",
+    value: "#AFA89A",
+    className: "bg-[#AFA89A]",
+    textClassName: "text-[#191714]",
+  },
+];
+
+const paletteGroups: PaletteGroup[] = [
+  {
+    title: "Mineral",
+    note: "차갑지만 네온으로 가지 않는 개발 블로그용 보조색",
+    colors: [
+      {
+        name: "oxide teal",
+        value: "#42534F",
+        className: "bg-[#42534F]",
+      },
+      {
+        name: "slate indigo",
+        value: "#4B5979",
+        className: "bg-[#4B5979]",
+      },
+      {
+        name: "dried moss",
+        value: "#626449",
+        className: "bg-[#626449]",
+      },
+    ],
+  },
+  {
+    title: "Earth",
+    note: "붓질과 종이 질감을 살리는 낮은 채도의 따뜻한 안료",
+    colors: [
+      {
+        name: "burnt sienna",
+        value: "#7E453D",
+        className: "bg-[#7E453D]",
+      },
+      {
+        name: "raw ochre",
+        value: "#B77F52",
+        className: "bg-[#B77F52]",
+      },
+      {
+        name: "mud violet",
+        value: "#6D5362",
+        className: "bg-[#6D5362]",
+      },
+    ],
+  },
+];
+
+const ColorChipCard = ({ color }: { color: ColorChip }) => {
+  return (
+    <article
+      className={cn(
+        "flex min-h-32 flex-col justify-between border-1 border-white/14 p-4 text-google-paper",
+        color.className,
+        color.textClassName
+      )}
+    >
+      <p className="text-lg font-semibold">{color.name}</p>
+      <p className="font-mono text-sm uppercase opacity-72">{color.value}</p>
+    </article>
+  );
+};
+
+const ColorPage = () => {
+  return (
+    <main className="min-h-screen bg-google-ink text-google-paper">
+      <section
+        className={cn(
+          "relative min-h-[calc(100dvh-56px)] overflow-hidden px-6 py-16 md:min-h-[calc(100dvh-100px)] md:px-10 md:py-24",
+          styles.surface
+        )}
+      >
+        <div className="relative z-10 mx-auto w-full max-w-[1632px]">
+          <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(360px,520px)] lg:items-end">
+            <div>
+              <p className="text-sm font-semibold uppercase text-google-paper/56">
+                /test/color
+              </p>
+              <h1 className="mt-8 max-w-[900px] break-keep text-[52px] font-normal leading-[1.02] md:text-[104px] md:leading-[0.95]">
+                아날로그 붓질을 위한 컬러
+              </h1>
+              <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
+                자개 팔레트는 보존하고, 블로그 본문에는 구아슈의 손맛을 더
+                잘 살리는 저채도 컬러를 따로 탐색합니다. 배경은 조용하게,
+                색은 썸네일과 강조 표면에서 먼저 검증합니다.
+              </p>
+            </div>
+
+            <aside className={cn("border-1 border-white/14 p-6", styles.brushField)}>
+              <p className="text-sm font-semibold uppercase text-google-paper/52">
+                direction
+              </p>
+              <p className="mt-16 max-w-[340px] break-keep text-3xl font-normal leading-tight">
+                black canvas, muted pigment, readable writing
+              </p>
+            </aside>
+          </div>
+
+          <div className="mt-16 grid gap-4 md:grid-cols-3">
+            {baseColors.map((color) => (
+              <ColorChipCard color={color} key={color.name} />
+            ))}
+          </div>
+
+          <div className="mt-16 grid gap-6 lg:grid-cols-2">
+            {paletteGroups.map((group) => (
+              <section
+                className="border-1 border-white/14 bg-white/[0.03] p-5"
+                key={group.title}
+              >
+                <div className="mb-5 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+                  <h2 className="text-3xl font-normal">{group.title}</h2>
+                  <p className="max-w-[320px] break-keep text-sm leading-6 text-google-paper/58">
+                    {group.note}
+                  </p>
+                </div>
+                <div className="grid gap-3 md:grid-cols-3">
+                  {group.colors.map((color) => (
+                    <ColorChipCard color={color} key={color.name} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <section className="mt-16 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+            <article className="border-1 border-white/14 bg-[#191714] p-6">
+              <p className="text-sm font-semibold uppercase text-google-paper/50">
+                readability sample
+              </p>
+              <h2 className="mt-12 max-w-[720px] break-keep text-5xl font-normal leading-tight md:text-6xl">
+                글을 읽는 표면은 끝까지 조용해야 한다
+              </h2>
+              <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72">
+                구아슈의 질감은 본문 뒤에 직접 깔지 않고, 제목 주변의 여백,
+                카드 이미지, 섹션 전환부에서만 낮은 농도로 드러냅니다.
+              </p>
+            </article>
+
+            <article className="border-1 border-white/14 bg-white/[0.03] p-5">
+              <div className={cn("h-32", styles.paperStrip)} />
+              <p className="mt-8 text-2xl font-semibold">thumbnail strip</p>
+              <p className="mt-4 break-keep text-sm leading-6 text-google-paper/60">
+                밝은 종이색은 전체 배경이 아니라 썸네일 안에서만 제한적으로
+                사용합니다.
+              </p>
+            </article>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default ColorPage;

--- a/src/app/test/color/page.tsx
+++ b/src/app/test/color/page.tsx
@@ -20,6 +20,15 @@ interface PaletteGroup {
   colors: ColorChip[];
 }
 
+interface Candidate {
+  eyebrow: string;
+  title: string;
+  note: string;
+  surfaceClassName: string;
+  stripClassName: string;
+  colors: ColorChip[];
+}
+
 const baseColors: ColorChip[] = [
   {
     name: "ink black",
@@ -85,6 +94,108 @@ const paletteGroups: PaletteGroup[] = [
   },
 ];
 
+const candidates: Candidate[] = [
+  {
+    eyebrow: "candidate 01",
+    title: "Ink Bone Minimal",
+    note: "본문 가독성을 최우선으로 두고, 붓질은 섹션 전환과 썸네일 표면에만 남기는 가장 조용한 후보",
+    surfaceClassName: styles.candidateInkBone,
+    stripClassName: styles.stripInkBone,
+    colors: [
+      baseColors[0],
+      baseColors[1],
+      {
+        name: "smoke umber",
+        value: "#3A322A",
+        className: "bg-[#3A322A]",
+      },
+      {
+        name: "soft ochre",
+        value: "#9C7450",
+        className: "bg-[#9C7450]",
+      },
+    ],
+  },
+  {
+    eyebrow: "candidate 02",
+    title: "Mineral Wash",
+    note: "검은 바탕 위에 산화 청록과 남색을 얇게 올린 후보. 차갑지만 AI 네온처럼 보이지 않게 낮은 채도로 제한",
+    surfaceClassName: styles.candidateMineral,
+    stripClassName: styles.stripMineral,
+    colors: [
+      baseColors[0],
+      {
+        name: "oxide teal",
+        value: "#42534F",
+        className: "bg-[#42534F]",
+      },
+      {
+        name: "slate indigo",
+        value: "#4B5979",
+        className: "bg-[#4B5979]",
+      },
+      {
+        name: "chalk blue",
+        value: "#9DAFC5",
+        className: "bg-[#9DAFC5]",
+        textClassName: "text-[#191714]",
+      },
+    ],
+  },
+  {
+    eyebrow: "candidate 03",
+    title: "Sienna Archive",
+    note: "아날로그 붓질의 따뜻함을 가장 직접적으로 드러내는 후보. 썸네일 시스템과 잘 맞는지 확인 필요",
+    surfaceClassName: styles.candidateSienna,
+    stripClassName: styles.stripSienna,
+    colors: [
+      baseColors[0],
+      {
+        name: "burnt sienna",
+        value: "#7E453D",
+        className: "bg-[#7E453D]",
+      },
+      {
+        name: "raw ochre",
+        value: "#B77F52",
+        className: "bg-[#B77F52]",
+      },
+      {
+        name: "paper ash",
+        value: "#AFA89A",
+        className: "bg-[#AFA89A]",
+        textClassName: "text-[#191714]",
+      },
+    ],
+  },
+  {
+    eyebrow: "candidate 04",
+    title: "Night Violet",
+    note: "감성은 가장 강하지만 본문 전체에 쓰기엔 위험한 후보. 강조 장면이나 대표 이미지용으로 비교",
+    surfaceClassName: styles.candidateViolet,
+    stripClassName: styles.stripViolet,
+    colors: [
+      baseColors[0],
+      {
+        name: "mud violet",
+        value: "#6D5362",
+        className: "bg-[#6D5362]",
+      },
+      {
+        name: "dust rose",
+        value: "#9A6B70",
+        className: "bg-[#9A6B70]",
+      },
+      {
+        name: "lavender ash",
+        value: "#B9ACC9",
+        className: "bg-[#B9ACC9]",
+        textClassName: "text-[#191714]",
+      },
+    ],
+  },
+];
+
 const ColorChipCard = ({ color }: { color: ColorChip }) => {
   return (
     <article
@@ -100,9 +211,125 @@ const ColorChipCard = ({ color }: { color: ColorChip }) => {
   );
 };
 
+const ColorGouacheFilters = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      className="absolute h-0 w-0 overflow-hidden"
+      focusable="false"
+    >
+      <filter id="color-gouache-paper">
+        <feTurbulence
+          baseFrequency="0.72"
+          numOctaves="4"
+          result="noise"
+          seed="17"
+          type="fractalNoise"
+        />
+        <feColorMatrix
+          in="noise"
+          result="paper"
+          type="matrix"
+          values="0.35 0 0 0 0.58 0 0.35 0 0 0.58 0 0 0.35 0 0.58 0 0 0 0.24 0"
+        />
+        <feBlend in="SourceGraphic" in2="paper" mode="multiply" />
+      </filter>
+      <filter id="color-gouache-bristle">
+        <feTurbulence
+          baseFrequency="0.018 0.16"
+          numOctaves="5"
+          result="grain"
+          seed="31"
+          type="fractalNoise"
+        />
+        <feDisplacementMap
+          in="SourceGraphic"
+          in2="grain"
+          scale="28"
+          xChannelSelector="R"
+          yChannelSelector="G"
+        />
+        <feColorMatrix
+          type="matrix"
+          values="1.08 0 0 0 -0.02 0 1.08 0 0 -0.02 0 0 1.08 0 -0.02 0 0 0 1 0"
+        />
+      </filter>
+    </svg>
+  );
+};
+
+const GouacheLayer = () => {
+  return (
+    <div aria-hidden="true" className={styles.gouacheLayer}>
+      <div className={cn(styles.gouacheTexture, styles.gouacheShadow)} />
+      <div className={cn(styles.gouacheTexture, styles.gouachePrimary)} />
+      <div className={cn(styles.gouacheTexture, styles.gouacheSecondary)} />
+      <div className={cn(styles.gouacheTexture, styles.gouacheLight)} />
+      <div className={styles.gouacheDryLine} />
+      <div className={styles.gouacheReadingField} />
+    </div>
+  );
+};
+
+const CandidatePreview = ({ candidate }: { candidate: Candidate }) => {
+  return (
+    <article
+      className={cn(
+        "relative min-h-[520px] overflow-hidden border-1 border-white/14 p-5 text-google-paper md:p-6",
+        styles.candidateSurface,
+        candidate.surfaceClassName
+      )}
+    >
+      <GouacheLayer />
+      <div className="relative z-10 flex min-h-[472px] flex-col">
+        <p className="text-sm font-semibold uppercase text-google-paper/50">
+          {candidate.eyebrow}
+        </p>
+        <h3 className="mt-6 max-w-[520px] break-keep text-4xl font-normal leading-tight md:text-5xl">
+          {candidate.title}
+        </h3>
+        <p className="mt-5 max-w-[560px] break-keep text-sm leading-6 text-google-paper/64 md:text-base md:leading-7">
+          {candidate.note}
+        </p>
+
+        <div
+          className={cn(
+            "mt-auto min-h-36 border-1 border-white/12 p-4",
+            styles.previewStrip,
+            candidate.stripClassName
+          )}
+        >
+          <p className="max-w-[360px] break-keep text-2xl font-semibold leading-tight">
+            글 표면은 조용하게, 이미지는 손으로 칠한 듯하게
+          </p>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-2 md:grid-cols-4">
+          {candidate.colors.map((color) => (
+            <div
+              className={cn(
+                "flex min-h-20 flex-col justify-between border-1 border-white/14 p-3 text-xs text-google-paper",
+                color.className,
+                color.textClassName
+              )}
+              key={color.name}
+            >
+              <span className="font-semibold">{color.name}</span>
+              <span className="font-mono uppercase opacity-72">
+                {color.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+};
+
 const ColorPage = () => {
   return (
     <main className="min-h-screen bg-google-ink text-google-paper">
+      <ColorGouacheFilters />
       <section
         className={cn(
           "relative min-h-[calc(100dvh-56px)] overflow-hidden px-6 py-16 md:min-h-[calc(100dvh-100px)] md:px-10 md:py-24",
@@ -161,6 +388,33 @@ const ColorPage = () => {
               </section>
             ))}
           </div>
+
+          <section className="mt-20">
+            <div className="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase text-google-paper/50">
+                  color + gouache candidates
+                </p>
+                <h2 className="mt-4 break-keep text-4xl font-normal leading-tight md:text-6xl">
+                  여러 후보를 같은 조건에서 비교
+                </h2>
+              </div>
+              <p className="max-w-[520px] break-keep text-sm leading-6 text-google-paper/60 md:text-base md:leading-7">
+                `/test/color`의 저채도 팔레트와 `/test/gouache`의 붓질 레이어
+                감각을 섞은 후보입니다. 본문 가독성, 썸네일 개성, 블로그 톤을
+                같이 비교합니다.
+              </p>
+            </div>
+
+            <div className="grid gap-5 xl:grid-cols-2">
+              {candidates.map((candidate) => (
+                <CandidatePreview
+                  candidate={candidate}
+                  key={candidate.title}
+                />
+              ))}
+            </div>
+          </section>
 
           <section className="mt-16 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
             <article className="border-1 border-white/14 bg-[#191714] p-6">

--- a/src/app/test/gouache/gouache.module.css
+++ b/src/app/test/gouache/gouache.module.css
@@ -1,10 +1,9 @@
 .surface {
   isolation: isolate;
   background:
-    radial-gradient(circle at 52% 34%, rgb(236 225 200 / 0.09), transparent 21%),
-    radial-gradient(circle at 76% 20%, rgb(79 127 115 / 0.2), transparent 30%),
-    radial-gradient(circle at 16% 78%, rgb(141 90 98 / 0.22), transparent 31%),
-    linear-gradient(138deg, #17140f 0%, #0e0d0a 42%, #211b14 100%);
+    radial-gradient(circle at 78% 12%, rgb(220 214 255 / 0.055), transparent 24%),
+    radial-gradient(circle at 9% 88%, rgb(255 234 244 / 0.045), transparent 26%),
+    linear-gradient(145deg, #1b1915 0%, #15130f 48%, #201c17 100%);
 }
 
 .surface::before,
@@ -17,179 +16,116 @@
 
 .surface::before {
   z-index: 1;
-  opacity: 0.34;
+  opacity: 0.22;
   background:
     repeating-linear-gradient(
-      104deg,
-      rgb(236 225 200 / 0.08) 0 1px,
-      transparent 1px 9px
-    ),
-    repeating-linear-gradient(
-      17deg,
-      rgb(0 0 0 / 0.24) 0 1px,
+      108deg,
+      rgb(255 253 247 / 0.055) 0 1px,
       transparent 1px 13px
     ),
-    radial-gradient(circle at 32% 60%, rgb(255 247 219 / 0.1), transparent 28%);
-  filter: url("#gouache-paper") contrast(1.3);
-  mix-blend-mode: overlay;
+    repeating-linear-gradient(
+      18deg,
+      rgb(0 0 0 / 0.22) 0 1px,
+      transparent 1px 17px
+    );
+  filter: url("#gouache-paper") contrast(1.18);
+  mix-blend-mode: soft-light;
 }
 
 .surface::after {
   z-index: 2;
-  opacity: 0.22;
+  opacity: 0.18;
   background:
-    radial-gradient(circle at 20% 40%, rgb(236 225 200 / 0.36) 0 1px, transparent 1px 5px),
-    radial-gradient(circle at 80% 20%, rgb(0 0 0 / 0.55) 0 1px, transparent 1px 6px);
+    radial-gradient(circle at 18% 42%, rgb(255 253 247 / 0.24) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 78% 18%, rgb(200 223 255 / 0.16) 0 1px, transparent 1px 6px);
   background-size:
-    8px 8px,
-    13px 13px;
-  mix-blend-mode: soft-light;
+    10px 10px,
+    15px 15px;
+  mix-blend-mode: screen;
 }
 
-.wash {
+.textureLayer {
   position: absolute;
   pointer-events: none;
-  filter: url("#gouache-bristle") blur(0.45px);
+  filter: url("#gouache-bristle") blur(0.4px);
   transform-origin: center;
 }
 
-.washShadow {
-  left: -22%;
-  bottom: -34%;
+.lacquerBloom {
+  left: -20%;
+  bottom: -40%;
   z-index: 3;
-  width: 82%;
-  height: 78%;
-  opacity: 0.74;
+  width: 68%;
+  height: 58%;
+  opacity: 0.5;
   background:
-    radial-gradient(ellipse at 35% 55%, rgb(0 0 0 / 0.92) 0 18%, rgb(69 56 41 / 0.72) 38%, transparent 69%),
-    conic-gradient(from 230deg at 48% 44%, transparent 0 13%, rgb(177 138 74 / 0.26) 16% 31%, rgb(0 0 0 / 0.58) 38% 52%, transparent 63% 100%);
-  border-radius: 48% 42% 52% 38%;
+    radial-gradient(ellipse at 38% 50%, rgb(0 0 0 / 0.78) 0 22%, rgb(255 241 228 / 0.07) 44%, transparent 72%),
+    conic-gradient(from 224deg at 52% 54%, transparent 0 20%, rgb(247 207 227 / 0.09) 28% 38%, transparent 48% 100%);
+  border-radius: 54% 42% 56% 38%;
   mix-blend-mode: multiply;
-  transform: rotate(-15deg) skewX(-8deg);
+  transform: rotate(-10deg) skewX(-6deg);
 }
 
-.washTeal {
-  right: -30%;
+.nacreVeil {
+  right: -22%;
   top: -20%;
   z-index: 4;
-  width: 68%;
-  height: 76%;
-  opacity: 0.56;
+  width: 60%;
+  height: 70%;
+  opacity: 0.34;
   background:
-    radial-gradient(ellipse at 32% 54%, rgb(79 127 115 / 0.78) 0 21%, rgb(127 128 84 / 0.32) 41%, transparent 69%),
-    conic-gradient(from 214deg at 42% 48%, transparent 0 18%, rgb(236 225 200 / 0.16) 24% 32%, rgb(79 127 115 / 0.42) 39% 52%, transparent 64% 100%);
-  border-radius: 54% 36% 52% 42%;
+    radial-gradient(ellipse at 42% 48%, rgb(255 253 247 / 0.2) 0 13%, rgb(220 214 255 / 0.14) 30%, transparent 64%),
+    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(255 234 244 / 0.2) 24% 31%, rgb(200 223 255 / 0.18) 38% 48%, transparent 58% 100%);
+  border-radius: 44% 58% 40% 54%;
   mix-blend-mode: screen;
-  transform: rotate(12deg) skewX(5deg);
+  transform: rotate(15deg) skewX(4deg);
 }
 
-.washRose {
-  left: -12%;
-  top: 4%;
+.shellMist {
+  left: 42%;
+  top: 18%;
   z-index: 5;
-  width: 62%;
-  height: 72%;
-  opacity: 0.58;
+  width: 38%;
+  height: 46%;
+  opacity: 0.24;
   background:
-    linear-gradient(62deg, transparent 0 13%, rgb(141 90 98 / 0.72) 27%, rgb(177 138 74 / 0.26) 49%, transparent 73%),
-    radial-gradient(ellipse at 38% 46%, rgb(236 225 200 / 0.16) 0 16%, transparent 45%);
-  border-radius: 58% 42% 54% 38%;
+    linear-gradient(118deg, transparent 0 20%, rgb(247 255 255 / 0.26) 28%, rgb(255 234 244 / 0.11) 44%, transparent 62%),
+    radial-gradient(ellipse at 48% 42%, rgb(255 253 247 / 0.14), transparent 48%);
+  border-radius: 58% 42% 52% 44%;
   mix-blend-mode: screen;
-  transform: rotate(-18deg) skewY(7deg);
+  transform: rotate(-13deg);
 }
 
-.washOchre {
-  right: -18%;
-  bottom: -24%;
+.dryLine {
+  position: absolute;
+  right: -8%;
+  top: 0;
   z-index: 6;
-  width: 72%;
-  height: 62%;
-  opacity: 0.52;
+  width: 44%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.11;
   background:
-    radial-gradient(ellipse at 54% 52%, rgb(177 138 74 / 0.58) 0 23%, rgb(127 128 84 / 0.28) 43%, transparent 70%),
-    linear-gradient(18deg, rgb(18 17 12 / 0.76) 0 12%, transparent 34% 100%);
-  border-radius: 45% 58% 36% 52%;
-  mix-blend-mode: screen;
-  transform: rotate(-9deg) skewX(-12deg);
-}
-
-.washIvory {
-  left: 33%;
-  top: 3%;
-  z-index: 7;
-  width: 50%;
-  height: 86%;
-  opacity: 0.32;
-  background:
-    radial-gradient(ellipse at 42% 38%, rgb(236 225 200 / 0.58) 0 12%, rgb(236 225 200 / 0.22) 30%, transparent 62%),
-    conic-gradient(from 194deg at 52% 48%, transparent 0 18%, rgb(236 225 200 / 0.26) 23% 31%, transparent 39% 100%),
     repeating-linear-gradient(
       103deg,
-      transparent 0 15px,
-      rgb(236 225 200 / 0.2) 17px 20px,
-      transparent 23px 44px
+      transparent 0 20px,
+      rgb(255 253 247 / 0.2) 22px 24px,
+      transparent 26px 54px
     );
-  border-radius: 44% 58% 38% 54%;
+  filter: url("#gouache-bristle") blur(1px);
   mix-blend-mode: screen;
-  transform: rotate(14deg) skewY(-6deg);
+  transform: rotate(3deg);
 }
 
-.dryBrush {
+.readingField {
   position: absolute;
-  left: 3%;
-  top: 17%;
-  z-index: 8;
-  width: 92%;
-  height: 76%;
+  left: 0;
+  top: 0;
+  z-index: 7;
+  width: min(72rem, 72%);
+  height: 100%;
   pointer-events: none;
-  opacity: 0.15;
-  background:
-    repeating-linear-gradient(
-      111deg,
-      transparent 0 17px,
-      rgb(236 225 200 / 0.28) 20px 23px,
-      transparent 25px 49px
-    ),
-    repeating-linear-gradient(
-      19deg,
-      transparent 0 24px,
-      rgb(79 127 115 / 0.18) 26px 29px,
-      transparent 31px 58px
-    );
-  filter: url("#gouache-bristle") blur(1.1px);
-  mix-blend-mode: screen;
-  transform: rotate(-4deg);
-}
-
-.paperLift {
-  position: absolute;
-  inset: 0;
-  z-index: 9;
-  pointer-events: none;
-  opacity: 0.38;
-  background:
-    radial-gradient(circle at 49% 25%, rgb(236 225 200 / 0.32), transparent 18%),
-    radial-gradient(circle at 68% 48%, rgb(79 127 115 / 0.2), transparent 25%),
-    linear-gradient(118deg, transparent 0 43%, rgb(236 225 200 / 0.2) 46% 50%, transparent 58%);
-  filter: url("#gouache-paper") blur(0.3px);
-  mix-blend-mode: screen;
-}
-
-.inkBloom {
-  position: absolute;
-  right: 10%;
-  bottom: 8%;
-  z-index: 10;
-  width: 36%;
-  aspect-ratio: 1;
-  pointer-events: none;
-  opacity: 0.46;
-  background:
-    radial-gradient(circle at 48% 42%, rgb(0 0 0 / 0.62) 0 14%, rgb(141 90 98 / 0.2) 34%, transparent 62%),
-    conic-gradient(from 64deg, transparent 0 14%, rgb(236 225 200 / 0.18) 21% 30%, rgb(79 127 115 / 0.16) 36% 46%, transparent 56% 100%);
-  border-radius: 48% 52% 43% 57%;
-  filter: url("#gouache-paper") blur(1px);
-  mix-blend-mode: screen;
+  background: linear-gradient(90deg, rgb(27 25 21 / 0.9) 0%, rgb(27 25 21 / 0.62) 58%, transparent 100%);
 }
 
 .strokeCard {
@@ -197,21 +133,22 @@
   overflow: hidden;
   isolation: isolate;
   background:
-    linear-gradient(145deg, rgb(236 225 200 / 0.09), rgb(0 0 0 / 0.24)),
-    #14120e;
+    linear-gradient(145deg, rgb(255 253 247 / 0.045), rgb(255 255 255 / 0.015)),
+    #1b1915;
 }
 
 .strokeCard::before {
   position: absolute;
-  inset: -24%;
+  inset: auto -16% -34% -16%;
   z-index: -1;
+  height: 74%;
   content: "";
   background:
-    radial-gradient(ellipse at 22% 70%, rgb(141 90 98 / 0.48), transparent 34%),
-    radial-gradient(ellipse at 72% 26%, rgb(79 127 115 / 0.54), transparent 31%),
-    radial-gradient(ellipse at 52% 52%, rgb(177 138 74 / 0.32), transparent 40%),
-    repeating-linear-gradient(112deg, transparent 0 11px, rgb(236 225 200 / 0.18) 12px 15px, transparent 16px 29px);
+    radial-gradient(ellipse at 20% 68%, rgb(255 234 244 / 0.16), transparent 36%),
+    radial-gradient(ellipse at 58% 44%, rgb(220 214 255 / 0.15), transparent 42%),
+    radial-gradient(ellipse at 84% 30%, rgb(200 223 255 / 0.16), transparent 34%),
+    repeating-linear-gradient(108deg, transparent 0 18px, rgb(255 253 247 / 0.1) 19px 21px, transparent 23px 48px);
   filter: url("#gouache-bristle") blur(0.7px);
   mix-blend-mode: screen;
-  transform: rotate(-8deg);
+  transform: rotate(-5deg);
 }

--- a/src/app/test/gouache/gouache.module.css
+++ b/src/app/test/gouache/gouache.module.css
@@ -1,0 +1,173 @@
+.surface {
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 24% 18%, rgb(255 255 255 / 0.72), transparent 24%),
+    radial-gradient(circle at 74% 16%, rgb(230 232 229 / 0.72), transparent 28%),
+    radial-gradient(circle at 82% 78%, rgb(186 188 184 / 0.34), transparent 32%),
+    linear-gradient(145deg, #f5f1e8 0%, #ebe7dd 48%, #d8d5cb 100%);
+}
+
+.surface::before,
+.surface::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+}
+
+.surface::before {
+  z-index: 1;
+  opacity: 0.28;
+  background:
+    repeating-linear-gradient(
+      106deg,
+      rgb(18 17 12 / 0.05) 0 1px,
+      transparent 1px 8px
+    ),
+    repeating-linear-gradient(
+      11deg,
+      rgb(255 255 255 / 0.34) 0 1px,
+      transparent 1px 11px
+    ),
+    radial-gradient(circle at 30% 60%, rgb(18 17 12 / 0.11), transparent 26%);
+  filter: url("#gouache-paper") contrast(1.32);
+  mix-blend-mode: multiply;
+}
+
+.surface::after {
+  z-index: 2;
+  opacity: 0.16;
+  background:
+    radial-gradient(circle at 20% 40%, rgb(18 17 12 / 0.34) 0 1px, transparent 1px 4px),
+    radial-gradient(circle at 80% 20%, rgb(255 255 255 / 0.4) 0 1px, transparent 1px 5px);
+  background-size:
+    7px 7px,
+    11px 11px;
+  mix-blend-mode: overlay;
+}
+
+.wash {
+  position: absolute;
+  pointer-events: none;
+  filter: url("#gouache-bristle") blur(0.4px);
+  mix-blend-mode: multiply;
+  transform-origin: center;
+}
+
+.washDark {
+  left: -12%;
+  bottom: -30%;
+  z-index: 3;
+  width: 72%;
+  height: 70%;
+  opacity: 0.52;
+  background:
+    radial-gradient(ellipse at 36% 58%, rgb(18 17 12 / 0.92) 0 18%, rgb(58 57 51 / 0.58) 35%, transparent 66%),
+    conic-gradient(from 232deg at 48% 44%, transparent 0 15%, rgb(18 17 12 / 0.62) 19% 31%, transparent 40% 100%);
+  border-radius: 50% 42% 48% 38%;
+  transform: rotate(-13deg) skewX(-9deg);
+}
+
+.washMiddle {
+  left: 10%;
+  top: 10%;
+  z-index: 4;
+  width: 58%;
+  height: 82%;
+  opacity: 0.42;
+  background:
+    linear-gradient(103deg, transparent 0 10%, rgb(45 44 39 / 0.56) 20%, rgb(121 121 113 / 0.3) 44%, transparent 70%),
+    radial-gradient(ellipse at 50% 50%, rgb(255 255 255 / 0.34) 0 15%, transparent 42%);
+  border-radius: 44% 54% 48% 60%;
+  transform: rotate(19deg) skewY(-11deg);
+}
+
+.washLight {
+  right: -8%;
+  top: -15%;
+  z-index: 5;
+  width: 62%;
+  height: 68%;
+  opacity: 0.48;
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.84) 0 16%, transparent 38%),
+    radial-gradient(ellipse at 44% 45%, rgb(216 217 212 / 0.54) 0 27%, transparent 64%);
+  border-radius: 38% 54% 44% 50%;
+  transform: rotate(16deg) skewX(8deg);
+}
+
+.dryBrush {
+  position: absolute;
+  left: 32%;
+  top: 3%;
+  z-index: 6;
+  width: 46%;
+  height: 90%;
+  pointer-events: none;
+  opacity: 0.13;
+  background:
+    repeating-linear-gradient(
+      101deg,
+      transparent 0 18px,
+      rgb(18 17 12 / 0.24) 20px 22px,
+      transparent 24px 46px
+    );
+  clip-path: polygon(11% 0, 62% 5%, 92% 20%, 78% 44%, 99% 66%, 56% 91%, 22% 100%, 0 72%, 16% 42%);
+  filter: url("#gouache-bristle") blur(1.8px);
+  mix-blend-mode: multiply;
+  transform: rotate(13deg);
+}
+
+.paperLift {
+  position: absolute;
+  inset: 0;
+  z-index: 7;
+  pointer-events: none;
+  opacity: 0.32;
+  background:
+    radial-gradient(circle at 50% 28%, rgb(255 255 255 / 0.72), transparent 18%),
+    radial-gradient(circle at 62% 48%, rgb(255 255 255 / 0.44), transparent 24%),
+    linear-gradient(116deg, transparent 0 46%, rgb(255 255 255 / 0.32) 48% 53%, transparent 59%);
+  filter: url("#gouache-paper") blur(0.2px);
+  mix-blend-mode: screen;
+}
+
+.strokeCard {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    linear-gradient(145deg, rgb(255 255 255 / 0.72), rgb(230 228 219 / 0.56)),
+    #ede8dd;
+}
+
+.strokeCard::before {
+  position: absolute;
+  inset: -22%;
+  z-index: -1;
+  content: "";
+  background:
+    radial-gradient(ellipse at 22% 70%, rgb(18 17 12 / 0.56), transparent 34%),
+    radial-gradient(ellipse at 74% 28%, rgb(255 255 255 / 0.76), transparent 30%),
+    repeating-linear-gradient(112deg, transparent 0 11px, rgb(18 17 12 / 0.16) 12px 15px, transparent 16px 28px);
+  filter: url("#gouache-bristle") blur(0.6px);
+  mix-blend-mode: multiply;
+  transform: rotate(-8deg);
+}
+
+.inkBloom {
+  position: absolute;
+  right: 7%;
+  bottom: 7%;
+  z-index: 8;
+  width: 30%;
+  aspect-ratio: 1;
+  pointer-events: none;
+  opacity: 0.34;
+  background:
+    radial-gradient(circle at 48% 42%, rgb(18 17 12 / 0.46) 0 16%, rgb(18 17 12 / 0.14) 32%, transparent 63%),
+    conic-gradient(from 64deg, transparent 0 18%, rgb(255 255 255 / 0.48) 23% 30%, transparent 35% 100%);
+  border-radius: 48% 52% 43% 57%;
+  filter: url("#gouache-paper") blur(1px);
+  mix-blend-mode: multiply;
+}

--- a/src/app/test/gouache/gouache.module.css
+++ b/src/app/test/gouache/gouache.module.css
@@ -1,10 +1,10 @@
 .surface {
   isolation: isolate;
   background:
-    radial-gradient(circle at 24% 18%, rgb(255 255 255 / 0.72), transparent 24%),
-    radial-gradient(circle at 74% 16%, rgb(230 232 229 / 0.72), transparent 28%),
-    radial-gradient(circle at 82% 78%, rgb(186 188 184 / 0.34), transparent 32%),
-    linear-gradient(145deg, #f5f1e8 0%, #ebe7dd 48%, #d8d5cb 100%);
+    radial-gradient(circle at 52% 34%, rgb(236 225 200 / 0.09), transparent 21%),
+    radial-gradient(circle at 76% 20%, rgb(79 127 115 / 0.2), transparent 30%),
+    radial-gradient(circle at 16% 78%, rgb(141 90 98 / 0.22), transparent 31%),
+    linear-gradient(138deg, #17140f 0%, #0e0d0a 42%, #211b14 100%);
 }
 
 .surface::before,
@@ -17,118 +17,178 @@
 
 .surface::before {
   z-index: 1;
-  opacity: 0.28;
+  opacity: 0.34;
   background:
     repeating-linear-gradient(
-      106deg,
-      rgb(18 17 12 / 0.05) 0 1px,
-      transparent 1px 8px
+      104deg,
+      rgb(236 225 200 / 0.08) 0 1px,
+      transparent 1px 9px
     ),
     repeating-linear-gradient(
-      11deg,
-      rgb(255 255 255 / 0.34) 0 1px,
-      transparent 1px 11px
+      17deg,
+      rgb(0 0 0 / 0.24) 0 1px,
+      transparent 1px 13px
     ),
-    radial-gradient(circle at 30% 60%, rgb(18 17 12 / 0.11), transparent 26%);
-  filter: url("#gouache-paper") contrast(1.32);
-  mix-blend-mode: multiply;
+    radial-gradient(circle at 32% 60%, rgb(255 247 219 / 0.1), transparent 28%);
+  filter: url("#gouache-paper") contrast(1.3);
+  mix-blend-mode: overlay;
 }
 
 .surface::after {
   z-index: 2;
-  opacity: 0.16;
+  opacity: 0.22;
   background:
-    radial-gradient(circle at 20% 40%, rgb(18 17 12 / 0.34) 0 1px, transparent 1px 4px),
-    radial-gradient(circle at 80% 20%, rgb(255 255 255 / 0.4) 0 1px, transparent 1px 5px);
+    radial-gradient(circle at 20% 40%, rgb(236 225 200 / 0.36) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 80% 20%, rgb(0 0 0 / 0.55) 0 1px, transparent 1px 6px);
   background-size:
-    7px 7px,
-    11px 11px;
-  mix-blend-mode: overlay;
+    8px 8px,
+    13px 13px;
+  mix-blend-mode: soft-light;
 }
 
 .wash {
   position: absolute;
   pointer-events: none;
-  filter: url("#gouache-bristle") blur(0.4px);
-  mix-blend-mode: multiply;
+  filter: url("#gouache-bristle") blur(0.45px);
   transform-origin: center;
 }
 
-.washDark {
-  left: -12%;
-  bottom: -30%;
+.washShadow {
+  left: -22%;
+  bottom: -34%;
   z-index: 3;
-  width: 72%;
-  height: 70%;
-  opacity: 0.52;
+  width: 82%;
+  height: 78%;
+  opacity: 0.74;
   background:
-    radial-gradient(ellipse at 36% 58%, rgb(18 17 12 / 0.92) 0 18%, rgb(58 57 51 / 0.58) 35%, transparent 66%),
-    conic-gradient(from 232deg at 48% 44%, transparent 0 15%, rgb(18 17 12 / 0.62) 19% 31%, transparent 40% 100%);
-  border-radius: 50% 42% 48% 38%;
-  transform: rotate(-13deg) skewX(-9deg);
+    radial-gradient(ellipse at 35% 55%, rgb(0 0 0 / 0.92) 0 18%, rgb(69 56 41 / 0.72) 38%, transparent 69%),
+    conic-gradient(from 230deg at 48% 44%, transparent 0 13%, rgb(177 138 74 / 0.26) 16% 31%, rgb(0 0 0 / 0.58) 38% 52%, transparent 63% 100%);
+  border-radius: 48% 42% 52% 38%;
+  mix-blend-mode: multiply;
+  transform: rotate(-15deg) skewX(-8deg);
 }
 
-.washMiddle {
-  left: 10%;
-  top: 10%;
+.washTeal {
+  right: -30%;
+  top: -20%;
   z-index: 4;
-  width: 58%;
-  height: 82%;
-  opacity: 0.42;
+  width: 68%;
+  height: 76%;
+  opacity: 0.56;
   background:
-    linear-gradient(103deg, transparent 0 10%, rgb(45 44 39 / 0.56) 20%, rgb(121 121 113 / 0.3) 44%, transparent 70%),
-    radial-gradient(ellipse at 50% 50%, rgb(255 255 255 / 0.34) 0 15%, transparent 42%);
-  border-radius: 44% 54% 48% 60%;
-  transform: rotate(19deg) skewY(-11deg);
+    radial-gradient(ellipse at 32% 54%, rgb(79 127 115 / 0.78) 0 21%, rgb(127 128 84 / 0.32) 41%, transparent 69%),
+    conic-gradient(from 214deg at 42% 48%, transparent 0 18%, rgb(236 225 200 / 0.16) 24% 32%, rgb(79 127 115 / 0.42) 39% 52%, transparent 64% 100%);
+  border-radius: 54% 36% 52% 42%;
+  mix-blend-mode: screen;
+  transform: rotate(12deg) skewX(5deg);
 }
 
-.washLight {
-  right: -8%;
-  top: -15%;
+.washRose {
+  left: -12%;
+  top: 4%;
   z-index: 5;
   width: 62%;
-  height: 68%;
-  opacity: 0.48;
+  height: 72%;
+  opacity: 0.58;
   background:
-    linear-gradient(135deg, rgb(255 255 255 / 0.84) 0 16%, transparent 38%),
-    radial-gradient(ellipse at 44% 45%, rgb(216 217 212 / 0.54) 0 27%, transparent 64%);
-  border-radius: 38% 54% 44% 50%;
-  transform: rotate(16deg) skewX(8deg);
+    linear-gradient(62deg, transparent 0 13%, rgb(141 90 98 / 0.72) 27%, rgb(177 138 74 / 0.26) 49%, transparent 73%),
+    radial-gradient(ellipse at 38% 46%, rgb(236 225 200 / 0.16) 0 16%, transparent 45%);
+  border-radius: 58% 42% 54% 38%;
+  mix-blend-mode: screen;
+  transform: rotate(-18deg) skewY(7deg);
+}
+
+.washOchre {
+  right: -18%;
+  bottom: -24%;
+  z-index: 6;
+  width: 72%;
+  height: 62%;
+  opacity: 0.52;
+  background:
+    radial-gradient(ellipse at 54% 52%, rgb(177 138 74 / 0.58) 0 23%, rgb(127 128 84 / 0.28) 43%, transparent 70%),
+    linear-gradient(18deg, rgb(18 17 12 / 0.76) 0 12%, transparent 34% 100%);
+  border-radius: 45% 58% 36% 52%;
+  mix-blend-mode: screen;
+  transform: rotate(-9deg) skewX(-12deg);
+}
+
+.washIvory {
+  left: 33%;
+  top: 3%;
+  z-index: 7;
+  width: 50%;
+  height: 86%;
+  opacity: 0.32;
+  background:
+    radial-gradient(ellipse at 42% 38%, rgb(236 225 200 / 0.58) 0 12%, rgb(236 225 200 / 0.22) 30%, transparent 62%),
+    conic-gradient(from 194deg at 52% 48%, transparent 0 18%, rgb(236 225 200 / 0.26) 23% 31%, transparent 39% 100%),
+    repeating-linear-gradient(
+      103deg,
+      transparent 0 15px,
+      rgb(236 225 200 / 0.2) 17px 20px,
+      transparent 23px 44px
+    );
+  border-radius: 44% 58% 38% 54%;
+  mix-blend-mode: screen;
+  transform: rotate(14deg) skewY(-6deg);
 }
 
 .dryBrush {
   position: absolute;
-  left: 32%;
-  top: 3%;
-  z-index: 6;
-  width: 46%;
-  height: 90%;
+  left: 3%;
+  top: 17%;
+  z-index: 8;
+  width: 92%;
+  height: 76%;
   pointer-events: none;
-  opacity: 0.13;
+  opacity: 0.15;
   background:
     repeating-linear-gradient(
-      101deg,
-      transparent 0 18px,
-      rgb(18 17 12 / 0.24) 20px 22px,
-      transparent 24px 46px
+      111deg,
+      transparent 0 17px,
+      rgb(236 225 200 / 0.28) 20px 23px,
+      transparent 25px 49px
+    ),
+    repeating-linear-gradient(
+      19deg,
+      transparent 0 24px,
+      rgb(79 127 115 / 0.18) 26px 29px,
+      transparent 31px 58px
     );
-  clip-path: polygon(11% 0, 62% 5%, 92% 20%, 78% 44%, 99% 66%, 56% 91%, 22% 100%, 0 72%, 16% 42%);
-  filter: url("#gouache-bristle") blur(1.8px);
-  mix-blend-mode: multiply;
-  transform: rotate(13deg);
+  filter: url("#gouache-bristle") blur(1.1px);
+  mix-blend-mode: screen;
+  transform: rotate(-4deg);
 }
 
 .paperLift {
   position: absolute;
   inset: 0;
-  z-index: 7;
+  z-index: 9;
   pointer-events: none;
-  opacity: 0.32;
+  opacity: 0.38;
   background:
-    radial-gradient(circle at 50% 28%, rgb(255 255 255 / 0.72), transparent 18%),
-    radial-gradient(circle at 62% 48%, rgb(255 255 255 / 0.44), transparent 24%),
-    linear-gradient(116deg, transparent 0 46%, rgb(255 255 255 / 0.32) 48% 53%, transparent 59%);
-  filter: url("#gouache-paper") blur(0.2px);
+    radial-gradient(circle at 49% 25%, rgb(236 225 200 / 0.32), transparent 18%),
+    radial-gradient(circle at 68% 48%, rgb(79 127 115 / 0.2), transparent 25%),
+    linear-gradient(118deg, transparent 0 43%, rgb(236 225 200 / 0.2) 46% 50%, transparent 58%);
+  filter: url("#gouache-paper") blur(0.3px);
+  mix-blend-mode: screen;
+}
+
+.inkBloom {
+  position: absolute;
+  right: 10%;
+  bottom: 8%;
+  z-index: 10;
+  width: 36%;
+  aspect-ratio: 1;
+  pointer-events: none;
+  opacity: 0.46;
+  background:
+    radial-gradient(circle at 48% 42%, rgb(0 0 0 / 0.62) 0 14%, rgb(141 90 98 / 0.2) 34%, transparent 62%),
+    conic-gradient(from 64deg, transparent 0 14%, rgb(236 225 200 / 0.18) 21% 30%, rgb(79 127 115 / 0.16) 36% 46%, transparent 56% 100%);
+  border-radius: 48% 52% 43% 57%;
+  filter: url("#gouache-paper") blur(1px);
   mix-blend-mode: screen;
 }
 
@@ -137,37 +197,21 @@
   overflow: hidden;
   isolation: isolate;
   background:
-    linear-gradient(145deg, rgb(255 255 255 / 0.72), rgb(230 228 219 / 0.56)),
-    #ede8dd;
+    linear-gradient(145deg, rgb(236 225 200 / 0.09), rgb(0 0 0 / 0.24)),
+    #14120e;
 }
 
 .strokeCard::before {
   position: absolute;
-  inset: -22%;
+  inset: -24%;
   z-index: -1;
   content: "";
   background:
-    radial-gradient(ellipse at 22% 70%, rgb(18 17 12 / 0.56), transparent 34%),
-    radial-gradient(ellipse at 74% 28%, rgb(255 255 255 / 0.76), transparent 30%),
-    repeating-linear-gradient(112deg, transparent 0 11px, rgb(18 17 12 / 0.16) 12px 15px, transparent 16px 28px);
-  filter: url("#gouache-bristle") blur(0.6px);
-  mix-blend-mode: multiply;
+    radial-gradient(ellipse at 22% 70%, rgb(141 90 98 / 0.48), transparent 34%),
+    radial-gradient(ellipse at 72% 26%, rgb(79 127 115 / 0.54), transparent 31%),
+    radial-gradient(ellipse at 52% 52%, rgb(177 138 74 / 0.32), transparent 40%),
+    repeating-linear-gradient(112deg, transparent 0 11px, rgb(236 225 200 / 0.18) 12px 15px, transparent 16px 29px);
+  filter: url("#gouache-bristle") blur(0.7px);
+  mix-blend-mode: screen;
   transform: rotate(-8deg);
-}
-
-.inkBloom {
-  position: absolute;
-  right: 7%;
-  bottom: 7%;
-  z-index: 8;
-  width: 30%;
-  aspect-ratio: 1;
-  pointer-events: none;
-  opacity: 0.34;
-  background:
-    radial-gradient(circle at 48% 42%, rgb(18 17 12 / 0.46) 0 16%, rgb(18 17 12 / 0.14) 32%, transparent 63%),
-    conic-gradient(from 64deg, transparent 0 18%, rgb(255 255 255 / 0.48) 23% 30%, transparent 35% 100%);
-  border-radius: 48% 52% 43% 57%;
-  filter: url("#gouache-paper") blur(1px);
-  mix-blend-mode: multiply;
 }

--- a/src/app/test/gouache/page.tsx
+++ b/src/app/test/gouache/page.tsx
@@ -19,43 +19,51 @@ interface PaletteChip {
 
 const layerCards: LayerCard[] = [
   {
-    title: "Carbon",
-    body: "warm black paper with uneven pigment load",
+    title: "Lacquer",
+    body: "quiet warm black field for long-form reading",
   },
   {
-    title: "Mineral",
-    body: "oxidized teal and olive washes over dark ground",
+    title: "Nacre",
+    body: "thin pearl, blush, lilac, and silver-blue glaze",
   },
   {
-    title: "Bloom",
-    body: "rose ash, ochre, and ivory dry-brush accents",
+    title: "Gouache",
+    body: "matte hand-painted grain kept away from body text",
   },
 ];
 
 const paletteChips: PaletteChip[] = [
   {
-    name: "carbon",
-    className: "bg-[#11100c]",
+    name: "lacquer",
+    className: "bg-[#1b1915]",
   },
   {
-    name: "teal",
-    className: "bg-[#4f7f73]",
+    name: "pearl",
+    className: "bg-[#fffdf7]",
   },
   {
-    name: "olive",
-    className: "bg-[#7f8054]",
+    name: "blush",
+    className: "bg-[#ffeaf4]",
   },
   {
     name: "rose",
-    className: "bg-[#8d5a62]",
+    className: "bg-[#f7cfe3]",
   },
   {
-    name: "ochre",
-    className: "bg-[#b18a4a]",
+    name: "lilac",
+    className: "bg-[#dcd6ff]",
   },
   {
-    name: "ivory",
-    className: "bg-[#ece1c8]",
+    name: "ice blue",
+    className: "bg-[#c8dfff]",
+  },
+  {
+    name: "silver",
+    className: "bg-[#f7ffff]",
+  },
+  {
+    name: "cream",
+    className: "bg-[#fff1e4]",
   },
 ];
 
@@ -116,14 +124,11 @@ const GouachePage = () => {
         )}
       >
         <GouacheFilters />
-        <div className={cn(styles.wash, styles.washShadow)} />
-        <div className={cn(styles.wash, styles.washTeal)} />
-        <div className={cn(styles.wash, styles.washRose)} />
-        <div className={cn(styles.wash, styles.washOchre)} />
-        <div className={cn(styles.wash, styles.washIvory)} />
-        <div className={styles.dryBrush} />
-        <div className={styles.paperLift} />
-        <div className={styles.inkBloom} />
+        <div className={cn(styles.textureLayer, styles.lacquerBloom)} />
+        <div className={cn(styles.textureLayer, styles.nacreVeil)} />
+        <div className={cn(styles.textureLayer, styles.shellMist)} />
+        <div className={styles.dryLine} />
+        <div className={styles.readingField} />
 
         <div className="relative z-10 mx-auto flex w-full max-w-[1632px] flex-col gap-12 lg:min-h-[720px] lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-186">
@@ -131,18 +136,18 @@ const GouachePage = () => {
               Gouache Lab
             </p>
             <h1 className="max-w-[980px] break-keep text-[44px] font-normal leading-[1.08] text-google-paper md:text-[88px] md:leading-[0.98]">
-              검은 종이에 구아슈 쌓아보기
+              자개빛 구아슈를 최소한으로
             </h1>
             <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
-              흰 종이 질감 대신 warm black을 바닥으로 두고, 탁한 색 물감이
-              겹쳐진 배경을 테스트합니다. 이미지 자산 없이 CSS gradient, SVG
-              turbulence, blend-mode로만 만든 절차형 레이어입니다.
+              흰 자개, 연분홍, 연보라, 은청색을 검은 옻칠 표면 위에 아주
+              얇게 얹어봅니다. 본문 뒤는 비워두고 가장자리, 구분선,
+              프레임에서만 손으로 칠한 결을 드러냅니다.
             </p>
           </div>
 
           <aside className="w-full max-w-[420px] border-1 border-white/18 bg-google-ink/42 p-6 shadow-[0_24px_90px_rgb(0_0_0/0.34)] backdrop-blur-sm md:p-8">
             <p className="text-sm font-semibold uppercase text-google-paper/52">
-              v1 dark surface
+              v2 quiet nacre
             </p>
             <dl className="mt-7 grid grid-cols-2 gap-x-6 gap-y-5 text-sm">
               <div>
@@ -151,7 +156,7 @@ const GouachePage = () => {
               </div>
               <div>
                 <dt className="text-google-paper/46">z layers</dt>
-                <dd className="mt-1 text-2xl font-semibold">11</dd>
+                <dd className="mt-1 text-2xl font-semibold">7</dd>
               </div>
               <div>
                 <dt className="text-google-paper/46">base</dt>
@@ -167,7 +172,7 @@ const GouachePage = () => {
                 <span
                   aria-label={chip.name}
                   className={cn(
-                    "block h-9 w-9 border-1 border-white/24",
+                    "block h-8 w-8 border-1 border-white/24",
                     chip.className
                   )}
                   key={chip.name}
@@ -181,7 +186,7 @@ const GouachePage = () => {
           {layerCards.map((card) => (
             <article
               className={cn(
-                "min-h-[190px] border-1 border-white/18 p-5 text-google-paper shadow-[0_18px_70px_rgb(0_0_0/0.28)]",
+                "min-h-[190px] border-1 border-white/14 p-5 text-google-paper shadow-[0_18px_70px_rgb(0_0_0/0.2)]",
                 styles.strokeCard
               )}
               key={card.title}

--- a/src/app/test/gouache/page.tsx
+++ b/src/app/test/gouache/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import { cn } from "@/utils/tailwind-util";
+import styles from "./gouache.module.css";
+
+export const metadata: Metadata = {
+  title: "Gouache Test | ou9999.dev",
+  description: "Procedural gouache background test page",
+};
+
+interface LayerCard {
+  title: string;
+  body: string;
+}
+
+const layerCards: LayerCard[] = [
+  {
+    title: "Paper",
+    body: "fixed grain, warm base, lifted white pigment",
+  },
+  {
+    title: "Wash",
+    body: "large blurred shapes with multiply blending",
+  },
+  {
+    title: "Brush",
+    body: "distorted streaks from SVG turbulence",
+  },
+];
+
+const GouacheFilters = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      className="absolute h-0 w-0 overflow-hidden"
+      focusable="false"
+    >
+      <filter id="gouache-paper">
+        <feTurbulence
+          baseFrequency="0.72"
+          numOctaves="4"
+          result="noise"
+          seed="17"
+          type="fractalNoise"
+        />
+        <feColorMatrix
+          in="noise"
+          result="paper"
+          type="matrix"
+          values="0.35 0 0 0 0.58 0 0.35 0 0 0.58 0 0 0.35 0 0.58 0 0 0 0.24 0"
+        />
+        <feBlend in="SourceGraphic" in2="paper" mode="multiply" />
+      </filter>
+      <filter id="gouache-bristle">
+        <feTurbulence
+          baseFrequency="0.018 0.16"
+          numOctaves="5"
+          result="grain"
+          seed="31"
+          type="fractalNoise"
+        />
+        <feDisplacementMap
+          in="SourceGraphic"
+          in2="grain"
+          scale="28"
+          xChannelSelector="R"
+          yChannelSelector="G"
+        />
+        <feColorMatrix
+          type="matrix"
+          values="1.08 0 0 0 -0.02 0 1.08 0 0 -0.02 0 0 1.08 0 -0.02 0 0 0 1 0"
+        />
+      </filter>
+    </svg>
+  );
+};
+
+const GouachePage = () => {
+  return (
+    <main className="min-h-screen overflow-hidden bg-google-paper text-google-ink">
+      <section
+        className={cn(
+          "relative isolate min-h-[calc(100dvh-56px)] overflow-hidden px-6 py-14 md:min-h-[calc(100dvh-100px)] md:px-10 md:py-20",
+          styles.surface
+        )}
+      >
+        <GouacheFilters />
+        <div className={cn(styles.wash, styles.washDark)} />
+        <div className={cn(styles.wash, styles.washMiddle)} />
+        <div className={cn(styles.wash, styles.washLight)} />
+        <div className={styles.dryBrush} />
+        <div className={styles.paperLift} />
+        <div className={styles.inkBloom} />
+
+        <div className="relative z-10 mx-auto flex w-full max-w-[1632px] flex-col gap-12 lg:min-h-[720px] lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-186">
+            <p className="mb-5 text-sm font-semibold uppercase text-google-ink/60">
+              Gouache Lab
+            </p>
+            <h1 className="max-w-[900px] break-keep text-[44px] font-normal leading-[1.08] text-google-ink md:text-[88px] md:leading-[0.98]">
+              붓칠을 이미지 없이 쌓아보기
+            </h1>
+            <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-ink/72 md:text-xl md:leading-9">
+              CSS gradient, SVG turbulence, blend-mode만으로 만든 절차형
+              구아슈 배경입니다. 최종 블로그 디자인으로 옮기기 전에 이
+              페이지에서 밀도와 대비를 계속 조정합니다.
+            </p>
+          </div>
+
+          <aside className="w-full max-w-[420px] border-1 border-google-ink/25 bg-white/42 p-6 shadow-[0_24px_80px_rgb(18_17_12/0.16)] backdrop-blur-sm md:p-8">
+            <p className="text-sm font-semibold uppercase text-google-ink/52">
+              v0 surface
+            </p>
+            <dl className="mt-7 grid grid-cols-2 gap-x-6 gap-y-5 text-sm">
+              <div>
+                <dt className="text-google-ink/48">image assets</dt>
+                <dd className="mt-1 text-2xl font-semibold">0</dd>
+              </div>
+              <div>
+                <dt className="text-google-ink/48">z layers</dt>
+                <dd className="mt-1 text-2xl font-semibold">8</dd>
+              </div>
+              <div>
+                <dt className="text-google-ink/48">base</dt>
+                <dd className="mt-1 text-2xl font-semibold">CSS</dd>
+              </div>
+              <div>
+                <dt className="text-google-ink/48">grain</dt>
+                <dd className="mt-1 text-2xl font-semibold">SVG</dd>
+              </div>
+            </dl>
+          </aside>
+        </div>
+
+        <div className="relative z-10 mx-auto mt-12 grid w-full max-w-[1632px] grid-cols-1 gap-4 md:grid-cols-3">
+          {layerCards.map((card) => (
+            <article
+              className={cn(
+                "min-h-[190px] border-1 border-google-ink/22 p-5 text-google-ink shadow-[0_18px_60px_rgb(18_17_12/0.13)]",
+                styles.strokeCard
+              )}
+              key={card.title}
+            >
+              <h2 className="text-2xl font-semibold">{card.title}</h2>
+              <p className="mt-20 max-w-[260px] text-sm leading-6 text-google-ink/64">
+                {card.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default GouachePage;

--- a/src/app/test/gouache/page.tsx
+++ b/src/app/test/gouache/page.tsx
@@ -4,7 +4,7 @@ import styles from "./gouache.module.css";
 
 export const metadata: Metadata = {
   title: "Gouache Test | ou9999.dev",
-  description: "Procedural gouache background test page",
+  description: "Mineral Wash gouache layer test page",
 };
 
 interface LayerCard {
@@ -19,51 +19,51 @@ interface PaletteChip {
 
 const layerCards: LayerCard[] = [
   {
-    title: "Lacquer",
-    body: "quiet warm black field for long-form reading",
+    title: "Graphite",
+    body: "near-black field that keeps long-form reading stable",
   },
   {
-    title: "Nacre",
-    body: "thin pearl, blush, lilac, and silver-blue glaze",
+    title: "Mineral",
+    body: "thin teal and slate wash kept below visible text",
   },
   {
     title: "Gouache",
-    body: "matte hand-painted grain kept away from body text",
+    body: "matte paper grain and dry brush edges following the viewport",
   },
 ];
 
 const paletteChips: PaletteChip[] = [
   {
-    name: "lacquer",
-    className: "bg-[#1b1915]",
+    name: "soot",
+    className: "bg-[#020303]",
   },
   {
-    name: "pearl",
-    className: "bg-[#fffdf7]",
+    name: "graphite black",
+    className: "bg-[#070707]",
   },
   {
-    name: "blush",
-    className: "bg-[#ffeaf4]",
+    name: "graphite surface",
+    className: "bg-[#101211]",
   },
   {
-    name: "rose",
-    className: "bg-[#f7cfe3]",
+    name: "mineral teal",
+    className: "bg-[#1F2A28]",
   },
   {
-    name: "lilac",
-    className: "bg-[#dcd6ff]",
+    name: "slate mineral",
+    className: "bg-[#202632]",
   },
   {
-    name: "ice blue",
-    className: "bg-[#c8dfff]",
+    name: "cool ash",
+    className: "bg-[#8B9290]",
   },
   {
-    name: "silver",
-    className: "bg-[#f7ffff]",
+    name: "chalk blue",
+    className: "bg-[#A2ADB3]",
   },
   {
-    name: "cream",
-    className: "bg-[#fff1e4]",
+    name: "cold paper",
+    className: "bg-[#E8ECEC]",
   },
 ];
 
@@ -86,7 +86,7 @@ const GouacheFilters = () => {
           in="noise"
           result="paper"
           type="matrix"
-          values="0.35 0 0 0 0.58 0 0.35 0 0 0.58 0 0 0.35 0 0.58 0 0 0 0.24 0"
+          values="0.35 0 0 0 0.5 0 0.35 0 0 0.5 0 0 0.35 0 0.5 0 0 0 0.2 0"
         />
         <feBlend in="SourceGraphic" in2="paper" mode="multiply" />
       </filter>
@@ -107,7 +107,7 @@ const GouacheFilters = () => {
         />
         <feColorMatrix
           type="matrix"
-          values="1.08 0 0 0 -0.02 0 1.08 0 0 -0.02 0 0 1.08 0 -0.02 0 0 0 1 0"
+          values="1.05 0 0 0 -0.02 0 1.05 0 0 -0.02 0 0 1.05 0 -0.02 0 0 0 1 0"
         />
       </filter>
     </svg>
@@ -133,21 +133,21 @@ const GouachePage = () => {
         <div className="relative z-10 mx-auto flex w-full max-w-[1632px] flex-col gap-12 lg:min-h-[720px] lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-186">
             <p className="mb-5 text-sm font-semibold uppercase text-google-paper/58">
-              Gouache Lab
+              Gouache Layer
             </p>
             <h1 className="max-w-[980px] break-keep text-[44px] font-normal leading-[1.08] text-google-paper md:text-[88px] md:leading-[0.98]">
-              자개빛 구아슈를 최소한으로
+              검은 Mineral Wash 레이어
             </h1>
             <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
-              흰 자개, 연분홍, 연보라, 은청색을 검은 옻칠 표면 위에 아주
-              얇게 얹어봅니다. 본문 뒤는 비워두고 가장자리, 구분선,
-              프레임에서만 손으로 칠한 결을 드러냅니다.
+              이 레이어가 최상단 layout에 배치되어 viewport를 따라다니는 최종
+              배경입니다. 색은 `/test/color`의 Mineral Wash만 사용하고, 구아슈
+              질감은 거의 검은 표면 안에서 낮은 농도로만 드러냅니다.
             </p>
           </div>
 
-          <aside className="w-full max-w-[420px] border-1 border-white/18 bg-google-ink/42 p-6 shadow-[0_24px_90px_rgb(0_0_0/0.34)] backdrop-blur-sm md:p-8">
+          <aside className="w-full max-w-[420px] border-1 border-mineral-blue/18 bg-google-ink/52 p-6 shadow-[0_24px_90px_rgb(0_0_0/0.34)] backdrop-blur-sm md:p-8">
             <p className="text-sm font-semibold uppercase text-google-paper/52">
-              v2 quiet nacre
+              global fixed layer
             </p>
             <dl className="mt-7 grid grid-cols-2 gap-x-6 gap-y-5 text-sm">
               <div>
@@ -163,8 +163,8 @@ const GouachePage = () => {
                 <dd className="mt-1 text-2xl font-semibold">CSS</dd>
               </div>
               <div>
-                <dt className="text-google-paper/46">grain</dt>
-                <dd className="mt-1 text-2xl font-semibold">SVG</dd>
+                <dt className="text-google-paper/46">position</dt>
+                <dd className="mt-1 text-2xl font-semibold">fixed</dd>
               </div>
             </dl>
             <div className="mt-8 flex flex-wrap gap-2">
@@ -172,7 +172,7 @@ const GouachePage = () => {
                 <span
                   aria-label={chip.name}
                   className={cn(
-                    "block h-8 w-8 border-1 border-white/24",
+                    "block h-8 w-8 border-1 border-mineral-blue/24",
                     chip.className
                   )}
                   key={chip.name}
@@ -186,7 +186,7 @@ const GouachePage = () => {
           {layerCards.map((card) => (
             <article
               className={cn(
-                "min-h-[190px] border-1 border-white/14 p-5 text-google-paper shadow-[0_18px_70px_rgb(0_0_0/0.2)]",
+                "min-h-[190px] border-1 border-mineral-blue/14 p-5 text-google-paper shadow-[0_18px_70px_rgb(0_0_0/0.2)]",
                 styles.strokeCard
               )}
               key={card.title}

--- a/src/app/test/gouache/page.tsx
+++ b/src/app/test/gouache/page.tsx
@@ -12,18 +12,50 @@ interface LayerCard {
   body: string;
 }
 
+interface PaletteChip {
+  name: string;
+  className: string;
+}
+
 const layerCards: LayerCard[] = [
   {
-    title: "Paper",
-    body: "fixed grain, warm base, lifted white pigment",
+    title: "Carbon",
+    body: "warm black paper with uneven pigment load",
   },
   {
-    title: "Wash",
-    body: "large blurred shapes with multiply blending",
+    title: "Mineral",
+    body: "oxidized teal and olive washes over dark ground",
   },
   {
-    title: "Brush",
-    body: "distorted streaks from SVG turbulence",
+    title: "Bloom",
+    body: "rose ash, ochre, and ivory dry-brush accents",
+  },
+];
+
+const paletteChips: PaletteChip[] = [
+  {
+    name: "carbon",
+    className: "bg-[#11100c]",
+  },
+  {
+    name: "teal",
+    className: "bg-[#4f7f73]",
+  },
+  {
+    name: "olive",
+    className: "bg-[#7f8054]",
+  },
+  {
+    name: "rose",
+    className: "bg-[#8d5a62]",
+  },
+  {
+    name: "ochre",
+    className: "bg-[#b18a4a]",
+  },
+  {
+    name: "ivory",
+    className: "bg-[#ece1c8]",
   },
 ];
 
@@ -76,7 +108,7 @@ const GouacheFilters = () => {
 
 const GouachePage = () => {
   return (
-    <main className="min-h-screen overflow-hidden bg-google-paper text-google-ink">
+    <main className="min-h-screen overflow-hidden bg-google-ink text-google-paper">
       <section
         className={cn(
           "relative isolate min-h-[calc(100dvh-56px)] overflow-hidden px-6 py-14 md:min-h-[calc(100dvh-100px)] md:px-10 md:py-20",
@@ -84,50 +116,64 @@ const GouachePage = () => {
         )}
       >
         <GouacheFilters />
-        <div className={cn(styles.wash, styles.washDark)} />
-        <div className={cn(styles.wash, styles.washMiddle)} />
-        <div className={cn(styles.wash, styles.washLight)} />
+        <div className={cn(styles.wash, styles.washShadow)} />
+        <div className={cn(styles.wash, styles.washTeal)} />
+        <div className={cn(styles.wash, styles.washRose)} />
+        <div className={cn(styles.wash, styles.washOchre)} />
+        <div className={cn(styles.wash, styles.washIvory)} />
         <div className={styles.dryBrush} />
         <div className={styles.paperLift} />
         <div className={styles.inkBloom} />
 
         <div className="relative z-10 mx-auto flex w-full max-w-[1632px] flex-col gap-12 lg:min-h-[720px] lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-186">
-            <p className="mb-5 text-sm font-semibold uppercase text-google-ink/60">
+            <p className="mb-5 text-sm font-semibold uppercase text-google-paper/58">
               Gouache Lab
             </p>
-            <h1 className="max-w-[900px] break-keep text-[44px] font-normal leading-[1.08] text-google-ink md:text-[88px] md:leading-[0.98]">
-              붓칠을 이미지 없이 쌓아보기
+            <h1 className="max-w-[980px] break-keep text-[44px] font-normal leading-[1.08] text-google-paper md:text-[88px] md:leading-[0.98]">
+              검은 종이에 구아슈 쌓아보기
             </h1>
-            <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-ink/72 md:text-xl md:leading-9">
-              CSS gradient, SVG turbulence, blend-mode만으로 만든 절차형
-              구아슈 배경입니다. 최종 블로그 디자인으로 옮기기 전에 이
-              페이지에서 밀도와 대비를 계속 조정합니다.
+            <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/72 md:text-xl md:leading-9">
+              흰 종이 질감 대신 warm black을 바닥으로 두고, 탁한 색 물감이
+              겹쳐진 배경을 테스트합니다. 이미지 자산 없이 CSS gradient, SVG
+              turbulence, blend-mode로만 만든 절차형 레이어입니다.
             </p>
           </div>
 
-          <aside className="w-full max-w-[420px] border-1 border-google-ink/25 bg-white/42 p-6 shadow-[0_24px_80px_rgb(18_17_12/0.16)] backdrop-blur-sm md:p-8">
-            <p className="text-sm font-semibold uppercase text-google-ink/52">
-              v0 surface
+          <aside className="w-full max-w-[420px] border-1 border-white/18 bg-google-ink/42 p-6 shadow-[0_24px_90px_rgb(0_0_0/0.34)] backdrop-blur-sm md:p-8">
+            <p className="text-sm font-semibold uppercase text-google-paper/52">
+              v1 dark surface
             </p>
             <dl className="mt-7 grid grid-cols-2 gap-x-6 gap-y-5 text-sm">
               <div>
-                <dt className="text-google-ink/48">image assets</dt>
+                <dt className="text-google-paper/46">image assets</dt>
                 <dd className="mt-1 text-2xl font-semibold">0</dd>
               </div>
               <div>
-                <dt className="text-google-ink/48">z layers</dt>
-                <dd className="mt-1 text-2xl font-semibold">8</dd>
+                <dt className="text-google-paper/46">z layers</dt>
+                <dd className="mt-1 text-2xl font-semibold">11</dd>
               </div>
               <div>
-                <dt className="text-google-ink/48">base</dt>
+                <dt className="text-google-paper/46">base</dt>
                 <dd className="mt-1 text-2xl font-semibold">CSS</dd>
               </div>
               <div>
-                <dt className="text-google-ink/48">grain</dt>
+                <dt className="text-google-paper/46">grain</dt>
                 <dd className="mt-1 text-2xl font-semibold">SVG</dd>
               </div>
             </dl>
+            <div className="mt-8 flex flex-wrap gap-2">
+              {paletteChips.map((chip) => (
+                <span
+                  aria-label={chip.name}
+                  className={cn(
+                    "block h-9 w-9 border-1 border-white/24",
+                    chip.className
+                  )}
+                  key={chip.name}
+                />
+              ))}
+            </div>
           </aside>
         </div>
 
@@ -135,13 +181,13 @@ const GouachePage = () => {
           {layerCards.map((card) => (
             <article
               className={cn(
-                "min-h-[190px] border-1 border-google-ink/22 p-5 text-google-ink shadow-[0_18px_60px_rgb(18_17_12/0.13)]",
+                "min-h-[190px] border-1 border-white/18 p-5 text-google-paper shadow-[0_18px_70px_rgb(0_0_0/0.28)]",
                 styles.strokeCard
               )}
               key={card.title}
             >
               <h2 className="text-2xl font-semibold">{card.title}</h2>
-              <p className="mt-20 max-w-[260px] text-sm leading-6 text-google-ink/64">
+              <p className="mt-20 max-w-[260px] text-sm leading-6 text-google-paper/62">
                 {card.body}
               </p>
             </article>

--- a/src/app/test/gouache/page.tsx
+++ b/src/app/test/gouache/page.tsx
@@ -58,7 +58,7 @@ const paletteChips: PaletteChip[] = [
     className: "bg-[#8B9290]",
   },
   {
-    name: "chalk blue",
+    name: "blue steel",
     className: "bg-[#A2ADB3]",
   },
   {

--- a/src/app/test/jagae/page.tsx
+++ b/src/app/test/jagae/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { cn } from "@/utils/tailwind-util";
+
+export const metadata: Metadata = {
+  title: "Jagae Test | ou9999.dev",
+  description: "Nacre gradient test page",
+};
+
+interface Swatch {
+  className: string;
+  name: string;
+}
+
+const swatches: Swatch[] = [
+  {
+    className: "bg-[#f8fff9]",
+    name: "pearl",
+  },
+  {
+    className: "bg-[#ffeaf4]",
+    name: "blush",
+  },
+  {
+    className: "bg-[#f7cfe3]",
+    name: "rose",
+  },
+  {
+    className: "bg-[#dcd6ff]",
+    name: "lilac",
+  },
+  {
+    className: "bg-[#c8dfff]",
+    name: "ice blue",
+  },
+  {
+    className: "bg-[#f7ffff]",
+    name: "silver",
+  },
+  {
+    className: "bg-[#fff1e4]",
+    name: "cream",
+  },
+];
+
+const JagaePage = () => {
+  return (
+    <main className="min-h-screen overflow-hidden bg-google-ink text-google-paper">
+      <section className="mx-auto w-full max-w-[1632px] px-6 py-24 md:py-32">
+        <div className="grid w-full gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(380px,520px)] lg:items-end">
+          <div>
+            <p className="font-mono text-xs uppercase leading-none text-google-paper/50 md:text-sm">
+              /test/jagae
+            </p>
+            <h1 className="mt-8 bg-nacre-moonlit bg-clip-text text-[88px] font-normal leading-[0.9] text-transparent md:text-[160px]">
+              자개
+            </h1>
+            <p className="mt-8 max-w-186 break-keep text-lg leading-8 text-google-paper/78 md:text-xl md:leading-9">
+              검은 옻칠 위에 흰 자개, 연분홍, 라벤더, 은청색 빛이 얇게
+              겹치는 방향으로 그라데이션을 조정합니다.
+            </p>
+          </div>
+
+          <div className="rounded-lg bg-nacre-moonlit p-px shadow-[0_28px_90px_rgb(0_0_0/0.34)]">
+            <div className="rounded-[7px] bg-google-ink p-5">
+              <div className="h-48 rounded-md bg-nacre-moonlit md:h-64" />
+              <div className="mt-5 grid grid-cols-7 gap-2">
+                {swatches.map((swatch) => (
+                  <div
+                    aria-label={swatch.name}
+                    className={cn(
+                      "h-10 rounded-sm border-1 border-white/16",
+                      swatch.className
+                    )}
+                    key={swatch.name}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-20 h-px w-full bg-nacre-moonlit" />
+
+        <div className="mt-16 grid gap-6 lg:grid-cols-3">
+          <article className="rounded-lg border-1 border-white/12 bg-white/5 p-6">
+            <p className="bg-nacre-moonlit bg-clip-text text-5xl font-normal leading-none text-transparent md:text-6xl">
+              Shell Text
+            </p>
+            <p className="mt-20 text-sm leading-6 text-google-paper/62">
+              Large title, logo, link hover
+            </p>
+          </article>
+
+          <article className="rounded-lg bg-nacre-moonlit p-px">
+            <div className="h-full rounded-[7px] bg-google-ink p-6">
+              <div className="h-32 rounded-md bg-[radial-gradient(circle_at_22%_18%,rgb(255_255_255/0.12),transparent_28%),linear-gradient(135deg,rgb(31_29_25),rgb(14_13_10))]" />
+              <p className="mt-20 text-sm leading-6 text-google-paper/62">
+                Hairline frame
+              </p>
+            </div>
+          </article>
+
+          <article className="rounded-lg border-1 border-white/12 bg-white/5 p-6">
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full border-1 border-white/22 px-3 py-1.5 font-mono text-sm uppercase leading-none text-google-paper">
+                lacquer
+              </span>
+              <span className="rounded-full bg-nacre-moonlit px-3 py-1.5 font-mono text-sm uppercase leading-none text-google-ink">
+                nacre
+              </span>
+            </div>
+            <p className="mt-28 text-sm leading-6 text-google-paper/62">
+              Tag and action states
+            </p>
+          </article>
+        </div>
+
+        <div className="mt-6 rounded-lg bg-nacre-moonlit p-px">
+          <div className="relative aspect-[16/9] overflow-hidden rounded-[7px] bg-google-ink">
+            <Image
+              alt="Jagae image frame sample"
+              className="object-cover"
+              fill
+              sizes="(max-width: 768px) 100vw, 96vw"
+              src="/imgs/header/ocr.webp"
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default JagaePage;

--- a/src/app/test/layout.tsx
+++ b/src/app/test/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { notFound } from "next/navigation";
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+interface TestLayoutProps {
+  children: ReactNode;
+}
+
+const TestLayout = ({ children }: TestLayoutProps) => {
+  if (process.env.NODE_ENV !== "development") {
+    notFound();
+  }
+
+  return <>{children}</>;
+};
+
+export default TestLayout;

--- a/src/components/background/mineral-wash-background.module.css
+++ b/src/components/background/mineral-wash-background.module.css
@@ -28,7 +28,7 @@
       rgb(0 0 0 / 0.24) 0 1px,
       transparent 1px 17px
     );
-  filter: url("#gouache-paper") contrast(1.18);
+  filter: url("#mineral-gouache-paper") contrast(1.18);
   mix-blend-mode: soft-light;
 }
 
@@ -47,7 +47,7 @@
 .textureLayer {
   position: absolute;
   pointer-events: none;
-  filter: url("#gouache-bristle") blur(0.4px);
+  filter: url("#mineral-gouache-bristle") blur(0.4px);
   transform-origin: center;
 }
 
@@ -112,7 +112,7 @@
       rgb(232 236 236 / 0.16) 22px 24px,
       transparent 26px 54px
     );
-  filter: url("#gouache-bristle") blur(1px);
+  filter: url("#mineral-gouache-bristle") blur(1px);
   mix-blend-mode: screen;
   transform: rotate(3deg);
 }
@@ -126,29 +126,4 @@
   height: 100%;
   pointer-events: none;
   background: linear-gradient(90deg, rgb(7 7 7 / 0.94) 0%, rgb(7 7 7 / 0.7) 58%, transparent 100%);
-}
-
-.strokeCard {
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  background:
-    linear-gradient(145deg, rgb(232 236 236 / 0.035), rgb(255 255 255 / 0.01)),
-    #070707;
-}
-
-.strokeCard::before {
-  position: absolute;
-  inset: auto -16% -34% -16%;
-  z-index: -1;
-  height: 74%;
-  content: "";
-  background:
-    radial-gradient(ellipse at 20% 68%, rgb(31 42 40 / 0.24), transparent 36%),
-    radial-gradient(ellipse at 58% 44%, rgb(32 38 50 / 0.2), transparent 42%),
-    radial-gradient(ellipse at 84% 30%, rgb(162 173 179 / 0.12), transparent 34%),
-    linear-gradient(108deg, transparent 0 18%, rgb(232 236 236 / 0.05) 28%, transparent 44% 100%);
-  filter: url("#gouache-bristle") blur(0.7px);
-  mix-blend-mode: screen;
-  transform: rotate(-5deg);
 }

--- a/src/components/background/mineral-wash-background.tsx
+++ b/src/components/background/mineral-wash-background.tsx
@@ -1,0 +1,72 @@
+import { cn } from "@/utils/tailwind-util";
+import styles from "./mineral-wash-background.module.css";
+
+const MineralWashFilters = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      className="absolute h-0 w-0 overflow-hidden"
+      focusable="false"
+    >
+      <filter id="mineral-gouache-paper">
+        <feTurbulence
+          baseFrequency="0.72"
+          numOctaves="4"
+          result="noise"
+          seed="17"
+          type="fractalNoise"
+        />
+        <feColorMatrix
+          in="noise"
+          result="paper"
+          type="matrix"
+          values="0.35 0 0 0 0.5 0 0.35 0 0 0.5 0 0 0.35 0 0.5 0 0 0 0.2 0"
+        />
+        <feBlend in="SourceGraphic" in2="paper" mode="multiply" />
+      </filter>
+      <filter id="mineral-gouache-bristle">
+        <feTurbulence
+          baseFrequency="0.018 0.16"
+          numOctaves="5"
+          result="grain"
+          seed="31"
+          type="fractalNoise"
+        />
+        <feDisplacementMap
+          in="SourceGraphic"
+          in2="grain"
+          scale="28"
+          xChannelSelector="R"
+          yChannelSelector="G"
+        />
+        <feColorMatrix
+          type="matrix"
+          values="1.05 0 0 0 -0.02 0 1.05 0 0 -0.02 0 0 1.05 0 -0.02 0 0 0 1 0"
+        />
+      </filter>
+    </svg>
+  );
+};
+
+const MineralWashBackground = () => {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none fixed inset-0 z-0 overflow-hidden",
+        styles.surface
+      )}
+    >
+      <MineralWashFilters />
+      <div className={cn(styles.textureLayer, styles.lacquerBloom)} />
+      <div className={cn(styles.textureLayer, styles.nacreVeil)} />
+      <div className={cn(styles.textureLayer, styles.shellMist)} />
+      <div className={styles.dryLine} />
+      <div className={styles.readingField} />
+      <div className="absolute inset-x-0 top-0 h-52 bg-gradient-to-b from-google-ink via-google-ink/80 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 h-72 bg-gradient-to-t from-google-ink via-google-ink/75 to-transparent" />
+    </div>
+  );
+};
+
+export { MineralWashBackground };

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -6,4 +6,16 @@ const nacreTextGradient = "bg-nacre-moonlit bg-clip-text text-transparent";
 const hoverNacreTextGradient =
   "transition-colors hover:bg-nacre-moonlit hover:bg-clip-text hover:text-transparent";
 
-export { hoverGradient, hoverNacreTextGradient, nacreTextGradient };
+const mineralTextGradient =
+  "text-google-paper md:bg-mineral-lettering md:bg-clip-text md:text-transparent";
+
+const hoverMineralTextGradient =
+  "transition-colors hover:bg-mineral-lettering hover:bg-clip-text hover:text-transparent";
+
+export {
+  hoverGradient,
+  hoverMineralTextGradient,
+  hoverNacreTextGradient,
+  mineralTextGradient,
+  nacreTextGradient,
+};

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -7,7 +7,7 @@ const hoverNacreTextGradient =
   "transition-colors hover:bg-nacre-moonlit hover:bg-clip-text hover:text-transparent";
 
 const mineralTextGradient =
-  "text-google-paper md:bg-mineral-lettering md:bg-clip-text md:text-transparent";
+  "bg-mineral-lettering bg-clip-text text-transparent";
 
 const hoverMineralTextGradient =
   "transition-colors hover:bg-mineral-lettering hover:bg-clip-text hover:text-transparent";

--- a/src/components/common/tag-link.tsx
+++ b/src/components/common/tag-link.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { hoverNacreTextGradient } from "@/components/common/styles";
+import { hoverMineralTextGradient } from "@/components/common/styles";
 import { cn } from "@/utils/tailwind-util";
 
 interface TagProps {
@@ -15,11 +15,11 @@ const Tag = ({ tag, variant = "paper" }: TagProps) => {
           className={cn(
             "cursor-pointer rounded-full border px-3 py-1.5 font-mono text-base uppercase leading-none transition-colors",
             variant === "ink" &&
-              "border-google-ink/40 text-google-ink hover:bg-google-ink hover:text-google-paper",
+              "border-mineral-ink/40 text-mineral-ink hover:bg-mineral-ink hover:text-mineral-bone",
             variant === "paper" &&
               cn(
-                "border-white/40 text-google-paper hover:border-white/80",
-                hoverNacreTextGradient
+                "border-mineral-blue/32 text-google-paper hover:border-mineral-blue/70",
+                hoverMineralTextGradient
               )
           )}
         >

--- a/src/components/content-header/content-header.tsx
+++ b/src/components/content-header/content-header.tsx
@@ -1,5 +1,5 @@
 import { Tag } from "@/components/common/tag-link";
-import { nacreTextGradient } from "@/components/common/styles";
+import { mineralTextGradient } from "@/components/common/styles";
 import { formatDateToString } from "@/utils/date-util";
 import { cn } from "@/utils/tailwind-util";
 import {
@@ -31,7 +31,7 @@ const ContentHeader = ({
   return (
     <ContentHeaderMotionRoot
       className={cn(
-        "w-full bg-google-ink px-6 text-google-paper",
+        "w-full bg-transparent px-6 text-google-paper",
         main
           ? "pb-8 pt-32 md:pb-8 md:pt-32"
           : "pb-16 pt-24 md:pb-24 md:pt-[126px]"
@@ -47,7 +47,7 @@ const ContentHeader = ({
           <ContentHeaderMotionTitle
             className={cn(
               "w-full text-5xl font-normal leading-none sm:text-6xl md:text-7xl lg:text-[90px] lg:leading-[0.95]",
-              nacreTextGradient,
+              mineralTextGradient,
               date ? "mt-10 md:mt-[51px]" : "mt-0"
             )}
           >
@@ -59,7 +59,7 @@ const ContentHeader = ({
               !main && "md:mt-16"
             )}
           >
-            <div className="max-w-2xl text-base text-current md:text-lg">
+            <div className="max-w-2xl text-base text-google-paper/78 md:text-lg">
               <p>{main ? text : "OU9999"}</p>
             </div>
             {tags && (
@@ -75,8 +75,8 @@ const ContentHeader = ({
         {img && (
           <ContentHeaderMotionImage
             className={cn(
-              "relative mt-10 aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_28px_90px_rgb(0_0_0/0.26)] md:mt-12",
-              main && "bg-gradient-to-t from-gray-100 via-gray-300 to-gray-400"
+              "relative mt-10 aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-mineral-blue/20 bg-mineral-frame shadow-[0_28px_90px_rgb(4_8_8/0.34)] ring-1 ring-mineral-bone/5 md:mt-12",
+              main && "bg-mineral-brush-soft"
             )}
           >
             <ImageWithPlaceholderHeader alt={title} img={img} preload />
@@ -84,7 +84,7 @@ const ContentHeader = ({
         )}
 
         {text && !main && (
-          <ContentHeaderMotionItem className="mx-auto mt-14 max-w-[684px] text-2xl leading-snug text-current md:mt-20 md:text-3xl">
+          <ContentHeaderMotionItem className="mx-auto mt-14 max-w-[684px] text-2xl leading-snug text-google-paper/82 md:mt-20 md:text-3xl">
             <p>{text}</p>
           </ContentHeaderMotionItem>
         )}

--- a/src/components/content-header/content-header.tsx
+++ b/src/components/content-header/content-header.tsx
@@ -75,7 +75,7 @@ const ContentHeader = ({
         {img && (
           <ContentHeaderMotionImage
             className={cn(
-              "relative mt-10 aspect-[16/9] w-full overflow-hidden md:mt-12",
+              "relative mt-10 aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_28px_90px_rgb(0_0_0/0.26)] md:mt-12",
               main && "bg-gradient-to-t from-gray-100 via-gray-300 to-gray-400"
             )}
           >

--- a/src/components/content-header/image-with-placeholder-header.tsx
+++ b/src/components/content-header/image-with-placeholder-header.tsx
@@ -20,6 +20,7 @@ const ImageWithPlaceholderHeader = ({
       alt={alt ?? "image" + img}
       src={imgSrc}
       fill
+      className="object-cover"
       sizes="(max-width: 768px) 100vw, 96vw"
       preload={preload}
       placeholder="blur"

--- a/src/components/main-section/about-me.tsx
+++ b/src/components/main-section/about-me.tsx
@@ -15,9 +15,9 @@ interface IconBoxProps {
 const IconBox = ({ link, icon, owl, subText }: IconBoxProps) => {
   return (
     <Link href={link}>
-      <div className="cursor-pointer flex justify-center p-2 rounded-md items-center space-x-1 hover:bg-gray-700">
+      <div className="flex cursor-pointer items-center justify-center space-x-1 rounded-md p-2 transition-colors hover:bg-mineral-teal/22">
         <div
-          className={cn("w-5 h-5", owl ? "fill-black" : "fill-white")}
+          className={cn("h-5 w-5", owl ? "fill-mineral-ink" : "fill-google-paper")}
         >
           {icon}
         </div>
@@ -29,8 +29,8 @@ const IconBox = ({ link, icon, owl, subText }: IconBoxProps) => {
 
 const AboutMe = () => {
   return (
-    <div className="w-full mt-14 md:mt-20 flex flex-col justify-center items-center">
-      <div className="w-full max-w-138 flex flex-col mt-10 space-y-10 text-xs md:text-sm text-slate-400">
+    <div className="mt-14 flex w-full flex-col items-center justify-center md:mt-20">
+      <div className="mt-10 flex w-full max-w-138 flex-col space-y-10 text-xs text-google-muted md:text-sm">
         <p>
           어머니가 작고 사소한 일이라도 불편한 부분이 있다면 개선하시는
           사람이라는 것. 그것은 나에게 특별한 감정을 불러일으킨다. 다른
@@ -42,7 +42,7 @@ const AboutMe = () => {
         </p>
       </div>
 
-      <p className="mt-16 md:mt-20 text-md md:text-lg text-center">
+      <p className="text-md mt-16 text-center text-google-paper md:mt-20 md:text-lg">
         오유진﹒FrontEnd Developer
       </p>
       <div className="mt-1 flex space-x-1">

--- a/src/components/main-section/image-with-placeholder.tsx
+++ b/src/components/main-section/image-with-placeholder.tsx
@@ -8,7 +8,7 @@ const ImageWithPlaceholder: React.FC<ImageProps> = (props) => {
 
   return (
     <div className="relative flex flex-col justify-center items-center">
-      <MediaReveal className="inline-flex max-w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_18px_60px_rgb(0_0_0/0.22)]">
+      <MediaReveal className="inline-flex max-w-full overflow-hidden rounded-lg border-1 border-mineral-blue/18 bg-mineral-frame shadow-[0_18px_60px_rgb(4_8_8/0.3)]">
         <Image
           {...props}
           alt={props.alt}
@@ -19,7 +19,7 @@ const ImageWithPlaceholder: React.FC<ImageProps> = (props) => {
         />
       </MediaReveal>
       {props.alt && (
-        <p className="my-1 text-gray-600 text-sm ">
+        <p className="my-1 text-sm text-google-muted">
           {props.alt}
         </p>
       )}

--- a/src/components/main-section/image-with-placeholder.tsx
+++ b/src/components/main-section/image-with-placeholder.tsx
@@ -8,11 +8,11 @@ const ImageWithPlaceholder: React.FC<ImageProps> = (props) => {
 
   return (
     <div className="relative flex flex-col justify-center items-center">
-      <MediaReveal className="inline-flex max-w-full">
+      <MediaReveal className="inline-flex max-w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_18px_60px_rgb(0_0_0/0.22)]">
         <Image
           {...props}
           alt={props.alt}
-          className={cn("rounded-lg h-auto max-w-full", props.className)}
+          className={cn("h-auto max-w-full rounded-lg", props.className)}
           sizes={props.sizes ?? "(max-width: 768px) 100vw, 804px"}
           placeholder="blur"
           blurDataURL={base64Data.base64}

--- a/src/components/main-section/post-box.tsx
+++ b/src/components/main-section/post-box.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { hoverNacreTextGradient } from "../common/styles";
+import { hoverMineralTextGradient } from "../common/styles";
 import { Tag } from "../common/tag-link";
 import { formatDateToString } from "@/utils/date-util";
 import { cn } from "@/utils/tailwind-util";
@@ -26,26 +26,27 @@ const PostBox = ({
     <article className="w-full flex flex-col">
       <Link
         href={`/p/${slug}`}
-        className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_18px_60px_rgb(0_0_0/0.22)] transition-transform duration-200 hover:-translate-y-1"
+        className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-mineral-blue/18 bg-mineral-frame shadow-[0_18px_60px_rgb(4_8_8/0.28)] transition duration-200 hover:-translate-y-1 hover:border-mineral-blue/34 hover:shadow-[0_22px_70px_rgb(66_83_79/0.24)]"
       >
         <ImageWithPlaceholderHeader alt={title} img={thumbnail} />
+        <span className="pointer-events-none absolute inset-0 bg-gradient-to-t from-mineral-soot/24 via-transparent to-mineral-bone/5" />
       </Link>
       <div className="mt-7 w-full">
         <Link href={`/p/${slug}`}>
           <p
             className={cn(
               "inline cursor-pointer text-2xl font-normal leading-tight text-google-paper sm:text-[32px] sm:leading-[35px]",
-              hoverNacreTextGradient
+              hoverMineralTextGradient
             )}
           >
             {title}
           </p>
         </Link>
       </div>
-      <div className="mt-4 w-full text-sm text-google-paper md:text-base">
+      <div className="mt-4 w-full text-sm text-google-muted md:text-base">
         <p>{formatDateToString(date)}</p>
       </div>
-      <div className="mt-2 w-full text-sm text-google-paper md:text-base">
+      <div className="mt-2 w-full text-sm text-google-paper/72 md:text-base">
         <p>{description}</p>
       </div>
       <div className="mt-5 flex w-full flex-wrap gap-2">

--- a/src/components/main-section/post-box.tsx
+++ b/src/components/main-section/post-box.tsx
@@ -26,7 +26,7 @@ const PostBox = ({
     <article className="w-full flex flex-col">
       <Link
         href={`/p/${slug}`}
-        className="relative block aspect-[16/9] w-full overflow-hidden"
+        className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border-1 border-white/15 bg-white/5 shadow-[0_18px_60px_rgb(0_0_0/0.22)] transition-transform duration-200 hover:-translate-y-1"
       >
         <ImageWithPlaceholderHeader alt={title} img={thumbnail} />
       </Link>

--- a/src/components/main-section/video-with-alt.tsx
+++ b/src/components/main-section/video-with-alt.tsx
@@ -1,6 +1,6 @@
 const VideoWithAlt: React.FC<HTMLVideoElement> = (props) => {
   return (
-    <div className="relative flex flex-col justify-center items-center">
+    <div className="relative flex flex-col items-center justify-center">
       <video
         className="rounded-lg"
         width={props.width}
@@ -14,9 +14,7 @@ const VideoWithAlt: React.FC<HTMLVideoElement> = (props) => {
         <source src={props.src} type="video/mp4" />
       </video>
       {props.ariaLabel && (
-        <p className="my-1 text-gray-600 text-sm ">
-          {props.ariaLabel}
-        </p>
+        <p className="my-1 text-sm text-google-muted">{props.ariaLabel}</p>
       )}
     </div>
   );

--- a/src/components/nav/header/back-button.tsx
+++ b/src/components/nav/header/back-button.tsx
@@ -14,7 +14,7 @@ const BackButton = () => {
     <button
       type="button"
       aria-label="뒤로 가기"
-      className="fixed top-10 right-10 w-10 h-10 fill-white"
+      className="fixed right-10 top-10 h-10 w-10 fill-google-paper transition-colors hover:fill-mineral-blue"
       onClick={handleBackClick}
     >
       <XIcon />

--- a/src/components/nav/site-footer.tsx
+++ b/src/components/nav/site-footer.tsx
@@ -13,7 +13,7 @@ const IconBox = ({ link, icon }: IIconBoxProps) => {
     <Link href={link}>
       <div
         aria-label={`link-for-${link}`}
-        className="w-4 h-4 md:w-5 md:h-5 cursor-pointer fill-google-paper transition-colors hover:fill-google-yellow"
+        className="w-4 h-4 cursor-pointer fill-google-paper transition-colors hover:fill-mineral-blue md:h-5 md:w-5"
       >
         {icon}
       </div>
@@ -25,8 +25,8 @@ const Footer = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <div className="w-full mt-20 flex justify-center border-t-1 border-white/20 bg-google-ink">
-      <div className="w-full max-w-276 p-5 flex justify-between items-center">
+    <div className="relative z-10 mt-20 flex w-full justify-center border-t-1 border-mineral-blue/16 bg-google-ink/86 backdrop-blur-sm">
+      <div className="flex w-full max-w-276 items-center justify-between p-5">
         <div className="flex flex-col space-y-1 text-google-paper">
           <div className="flex text-sm">
             <p>{currentYear}﹒©</p>

--- a/src/components/nav/site-header.tsx
+++ b/src/components/nav/site-header.tsx
@@ -1,17 +1,20 @@
 import Link from "next/link";
-import { hoverNacreTextGradient, nacreTextGradient } from "../common/styles";
+import {
+  hoverMineralTextGradient,
+  mineralTextGradient,
+} from "../common/styles";
 import { cn } from "@/utils/tailwind-util";
 import { PopoverButton } from "./header/popover-button";
 
 const Header = () => {
   return (
-    <header className="z-40 flex h-14 w-full items-center bg-google-ink px-6 text-google-paper md:h-[100px]">
+    <header className="relative z-40 flex h-14 w-full items-center border-b-1 border-mineral-blue/10 bg-google-ink/92 px-6 text-google-paper backdrop-blur-md md:h-[100px]">
       <nav className="mx-auto flex h-full w-full max-w-[1632px] items-center justify-between">
         <Link
           href={"/"}
           className={cn(
             "flex cursor-pointer items-center justify-center text-2xl font-bold md:text-3xl",
-            nacreTextGradient
+            mineralTextGradient
           )}
         >
           <span>&lt;</span>
@@ -24,7 +27,7 @@ const Header = () => {
             <p
               className={cn(
                 "text-lg font-semibold text-google-paper",
-                hoverNacreTextGradient
+                hoverMineralTextGradient
               )}
             >
               Home
@@ -34,7 +37,7 @@ const Header = () => {
             <p
               className={cn(
                 "text-lg font-semibold text-google-paper",
-                hoverNacreTextGradient
+                hoverMineralTextGradient
               )}
             >
               About
@@ -44,7 +47,7 @@ const Header = () => {
             <p
               className={cn(
                 "text-lg font-semibold text-google-paper",
-                hoverNacreTextGradient
+                hoverMineralTextGradient
               )}
             >
               Portfolio

--- a/src/components/portfolio/accordion-ui.tsx
+++ b/src/components/portfolio/accordion-ui.tsx
@@ -17,7 +17,7 @@ const AccordionTrigger = ({
     <button
       type="button"
       onClick={clickFn}
-      className="flex cursor-pointer hover:underline"
+      className="flex cursor-pointer hover:text-mineral-blue hover:underline"
     >
       <p>{triggerText}</p>
       <div className="w-3 h-3">

--- a/src/components/portfolio/carousel-img.tsx
+++ b/src/components/portfolio/carousel-img.tsx
@@ -13,12 +13,12 @@ const CarouselImg = ({ imgs }: CarouselProps) => {
   });
 
   return (
-    <div ref={emblaThumbsRef} className="w-auto overflow-x-scroll mt-3 mb-5">
-      <div className="w-auto flex flex-row space-x-2 h-32 py-1">
+    <div ref={emblaThumbsRef} className="mb-5 mt-3 w-auto overflow-x-scroll">
+      <div className="flex h-32 w-auto flex-row space-x-2 py-1">
         {imgs.map((img) => (
           <div
             key={"carousel" + img}
-            className="relative w-52 min-w-52 border border-slate-800 h-full rounded-md overflow-hidden"
+            className="relative h-full w-52 min-w-52 overflow-hidden rounded-md border border-mineral-blue/18 bg-mineral-frame"
           >
             <Image
               alt={`Portfolio screenshot: ${img}`}

--- a/src/components/portfolio/carousel-stack.tsx
+++ b/src/components/portfolio/carousel-stack.tsx
@@ -7,7 +7,7 @@ interface BadgeProps {
 
 const Badge = ({ text }: BadgeProps) => {
   return (
-    <div className="inline-flex whitespace-nowrap w-auto h-5 max-h-5 items-center rounded-md border border-slate-600 px-2.5 py-0.5 text-xs text-slate-50 bg-[#111827]">
+    <div className="inline-flex h-5 max-h-5 w-auto items-center whitespace-nowrap rounded-md border border-mineral-blue/24 bg-mineral-teal/18 px-2.5 py-0.5 text-xs text-google-paper">
       {text}
     </div>
   );
@@ -24,8 +24,8 @@ const CarouselStack = ({ stack }: CarouselProps) => {
   });
 
   return (
-    <div ref={emblaThumbsRef} className="w-auto overflow-x-scroll mt-2">
-      <div className="w-auto flex flex-row space-x-2 h-auto">
+    <div ref={emblaThumbsRef} className="mt-2 w-auto overflow-x-scroll">
+      <div className="flex h-auto w-auto flex-row space-x-2">
         {stack.map((skill, idx) => (
           <Badge key={skill + idx} text={skill} />
         ))}

--- a/src/components/portfolio/contact-link.tsx
+++ b/src/components/portfolio/contact-link.tsx
@@ -9,14 +9,16 @@ interface ContactLinkProps {
 
 const ContactLink = ({ title, link, linkText }: ContactLinkProps) => {
   return (
-    <div className="w-full flex">
-      <p className="w-3/12 text-slate-400">{title}</p>
+    <div className="flex w-full">
+      <p className="w-3/12 text-google-muted">{title}</p>
 
-      <div className="w-9/12 flex justify-start items-center space-x-[0.5px]">
+      <div className="flex w-9/12 items-center justify-start space-x-[0.5px]">
         <Link href={link}>
-          <p className="cursor-pointer hover:underline">{linkText}</p>
+          <p className="cursor-pointer text-google-paper hover:text-mineral-blue hover:underline">
+            {linkText}
+          </p>
         </Link>
-        <div className="w-3 h-3 fill-white stroke-white">
+        <div className="h-3 w-3 fill-mineral-blue stroke-mineral-blue">
           <LinkIcon />
         </div>
       </div>

--- a/src/components/portfolio/link-text.tsx
+++ b/src/components/portfolio/link-text.tsx
@@ -12,14 +12,16 @@ const LinkText = ({ link, text, className }: LinkTextProps) => {
   return (
     <div
       className={cn(
-        "w-full flex justify-start items-center space-x-[0.5px]",
+        "flex w-full items-center justify-start space-x-[0.5px]",
         className
       )}
     >
       <Link href={link}>
-        <p className="cursor-pointer underline">{text}</p>
+        <p className="cursor-pointer text-google-paper underline hover:text-mineral-blue">
+          {text}
+        </p>
       </Link>
-      <div className="w-3 h-3 fill-slate-400 stroke-slate-400">
+      <div className="h-3 w-3 fill-mineral-blue stroke-mineral-blue">
         <LinkIcon />
       </div>
     </div>

--- a/src/components/portfolio/portfolio-ui.tsx
+++ b/src/components/portfolio/portfolio-ui.tsx
@@ -9,7 +9,7 @@ interface PortfolioTitleProps {
 }
 
 const PortfolioTitle = ({ text }: PortfolioTitleProps) => {
-  return <p className="text-lg mt-14 mb-5">{text}</p>;
+  return <p className="mb-5 mt-14 text-lg text-google-paper">{text}</p>;
 };
 
 const PortfolioContent = ({
@@ -43,21 +43,23 @@ const ProjectLayout = ({
   children,
 }: ProjectLayoutProps) => {
   return (
-    <div className="w-full flex">
-      <div className="flex flex-col md:flex-row w-3/12 text-slate-400">
+    <div className="flex w-full">
+      <div className="flex w-3/12 flex-col text-google-muted md:flex-row">
         {dateFrom && <p>{dateFrom} -&nbsp;</p>}
         {dateTo && <p>{dateTo}</p>}
         {date && <p>{date}</p>}
       </div>
 
-      <div className="w-9/12 flex flex-col justify-start">
-        <div className="w-full flex justify-start items-center space-x-[0.5px]">
+      <div className="flex w-9/12 flex-col justify-start">
+        <div className="flex w-full items-center justify-start space-x-[0.5px]">
           {link ? (
             <>
               <Link href={link}>
-                <p className="cursor-pointer hover:underline">{projectTitle}</p>
+                <p className="cursor-pointer text-google-paper hover:text-mineral-blue hover:underline">
+                  {projectTitle}
+                </p>
               </Link>
-              <div className="w-3 h-3 fill-white stroke-white">
+              <div className="h-3 w-3 fill-mineral-blue stroke-mineral-blue">
                 <LinkIcon />
               </div>
             </>
@@ -65,7 +67,7 @@ const ProjectLayout = ({
             <p className="">{projectTitle}</p>
           )}
         </div>
-        <div className="w-full flex flex-col justify-start text-slate-400">
+        <div className="flex w-full flex-col justify-start text-google-muted">
           <p>{projectType}</p>
           {stack && <CarouselStack stack={stack} />}
           {imgs && <CarouselImg imgs={imgs} />}

--- a/src/css/prettyCode.css
+++ b/src/css/prettyCode.css
@@ -38,7 +38,7 @@
 }
 
 .prose code span[data-highlighted-line] {
-  @apply bg-indigo-400/10 rounded-sm;
+  @apply rounded-sm bg-mineral-blue/10;
 }
 
 .prose :not(pre) > code::before,
@@ -47,9 +47,9 @@
 }
 
 .prose :not(pre) > code {
-  @apply bg-gray-900 border border-gray-700 text-sm font-normal align-middle py-0.5 px-1 rounded;
+  @apply rounded border border-mineral-blue/18 bg-mineral-teal/14 px-1 py-0.5 align-middle text-sm font-normal;
 }
 
 figcaption[data-rehype-pretty-code-title] {
-  @apply bg-[rgb(26,34,39)] py-2 px-6 rounded-t-md border-b-1 border-b-slate-800 text-slate-400 translate-y-1;
+  @apply translate-y-1 rounded-t-md border-b-1 border-b-mineral-blue/16 bg-mineral-teal/16 px-6 py-2 text-google-muted;
 }

--- a/src/scripts/remove-test-output.mjs
+++ b/src/scripts/remove-test-output.mjs
@@ -1,0 +1,12 @@
+import { rmSync } from "node:fs";
+
+if (process.env.NODE_ENV === "development") {
+  process.exit(0);
+}
+
+const testOutputUrl = new URL("../../out/test", import.meta.url);
+
+rmSync(testOutputUrl, {
+  force: true,
+  recursive: true,
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,9 +8,9 @@ const config = {
   theme: {
     extend: {
       backgroundColor: {
-        "dark-bg": "rgb(15, 15, 15)",
-        "blur-black": "rgba(15, 15, 15, 0.4)",
-        "content-header-black": "#1B1A1E",
+        "dark-bg": "#070707",
+        "blur-black": "rgba(7, 7, 7, 0.58)",
+        "content-header-black": "#101211",
       },
       width: {
         "276": "68rem",
@@ -19,17 +19,41 @@ const config = {
         "2vh": "120dvh",
       },
       colors: {
-        "google-ink": "#1B1915",
-        "google-paper": "#FFFFFF",
-        "google-blue": "#1A73E8",
-        "google-muted": "#BDC1C6",
-        "google-yellow": "#FAE366",
-        "gradient-start": "#93A1F7",
-        "gradient-end": "#52C7C6",
+        "google-ink": "#070707",
+        "google-paper": "#E8ECEC",
+        "google-blue": "#A2ADB3",
+        "google-muted": "#8B9290",
+        "google-yellow": "#8D8173",
+        "gradient-start": "#E8ECEC",
+        "gradient-end": "#C8D1D2",
+        "mineral-ink": "#070707",
+        "mineral-soot": "#020303",
+        "mineral-graphite": "#101211",
+        "mineral-teal": "#1F2A28",
+        "mineral-indigo": "#202632",
+        "mineral-blue": "#A2ADB3",
+        "mineral-bone": "#E8ECEC",
+        "mineral-muted": "#8B9290",
+        "mineral-oxide": "#3A3030",
+        "mineral-clay": "#5B5148",
       },
       backgroundImage: {
         "nacre-moonlit":
           "linear-gradient(112deg, #FFFDF7 0%, #FFEAF4 8%, #F7CFE3 15%, #DCD6FF 24%, #C8DFFF 32%, #F7FFFF 41%, #FFF5EC 49%, #F4C8DC 58%, #DFD4FF 68%, #D7F3FF 77%, #FFF1E4 86%, #E8E9FF 94%, #FFFDF8 100%)",
+        "mineral-wash":
+          "linear-gradient(112deg, #0A0B0A 0%, #101211 48%, #080909 100%)",
+        "mineral-lettering":
+          "linear-gradient(112deg, #E8ECEC 0%, #DDE2E2 52%, #EEF1F0 100%)",
+        "mineral-canvas":
+          "radial-gradient(circle at 78% 12%, rgb(31 42 40 / 0.12), transparent 28%), radial-gradient(circle at 12% 84%, rgb(32 38 50 / 0.1), transparent 30%), linear-gradient(145deg, #070707 0%, #030404 48%, #0C0D0C 100%)",
+        "mineral-brush":
+          "radial-gradient(ellipse at 24% 72%, rgb(31 42 40 / 0.42), transparent 38%), radial-gradient(ellipse at 74% 32%, rgb(32 38 50 / 0.34), transparent 36%), linear-gradient(104deg, transparent 0 18%, rgb(162 173 179 / 0.07) 27%, transparent 43% 100%)",
+        "mineral-brush-soft":
+          "radial-gradient(ellipse at 20% 68%, rgb(58 48 48 / 0.1), transparent 38%), radial-gradient(ellipse at 58% 44%, rgb(31 42 40 / 0.22), transparent 42%), radial-gradient(ellipse at 84% 30%, rgb(162 173 179 / 0.1), transparent 34%), linear-gradient(118deg, transparent 0 24%, rgb(232 236 236 / 0.04) 32%, transparent 48% 100%)",
+        "mineral-grain":
+          "radial-gradient(circle at 18% 42%, rgb(232 236 236 / 0.035) 0 1px, transparent 1px 5px), radial-gradient(circle at 78% 18%, rgb(162 173 179 / 0.03) 0 1px, transparent 1px 6px)",
+        "mineral-frame":
+          "linear-gradient(145deg, rgb(232 236 236 / 0.055), rgb(162 173 179 / 0.05) 44%, rgb(31 42 40 / 0.16))",
       },
       fontFamily: {
         sans: ["LINE Seed Sans KR", "system-ui", "sans-serif"],
@@ -45,22 +69,22 @@ const config = {
       typography: {
         google: {
           css: {
-            "--tw-prose-body": "#FFFFFF",
-            "--tw-prose-headings": "#FFFFFF",
-            "--tw-prose-lead": "#FFFFFF",
-            "--tw-prose-links": "#1A73E8",
-            "--tw-prose-bold": "#FFFFFF",
-            "--tw-prose-counters": "#FFFFFF",
-            "--tw-prose-bullets": "#FFFFFF",
-            "--tw-prose-hr": "rgba(255, 255, 255, 0.2)",
-            "--tw-prose-quotes": "#FFFFFF",
-            "--tw-prose-quote-borders": "#1A73E8",
-            "--tw-prose-captions": "#FFFFFF",
-            "--tw-prose-code": "#FAE366",
-            "--tw-prose-pre-code": "#FFFFFF",
-            "--tw-prose-pre-bg": "rgba(255, 255, 255, 0.08)",
-            "--tw-prose-th-borders": "rgba(255, 255, 255, 0.2)",
-            "--tw-prose-td-borders": "rgba(255, 255, 255, 0.2)",
+            "--tw-prose-body": "#E8ECEC",
+            "--tw-prose-headings": "#E8ECEC",
+            "--tw-prose-lead": "#E8ECEC",
+            "--tw-prose-links": "#A2ADB3",
+            "--tw-prose-bold": "#E8ECEC",
+            "--tw-prose-counters": "#8B9290",
+            "--tw-prose-bullets": "#8B9290",
+            "--tw-prose-hr": "rgba(162, 173, 179, 0.2)",
+            "--tw-prose-quotes": "#E8ECEC",
+            "--tw-prose-quote-borders": "#1F2A28",
+            "--tw-prose-captions": "#8B9290",
+            "--tw-prose-code": "#D0D7D7",
+            "--tw-prose-pre-code": "#E8ECEC",
+            "--tw-prose-pre-bg": "rgba(31, 42, 40, 0.18)",
+            "--tw-prose-th-borders": "rgba(162, 173, 179, 0.2)",
+            "--tw-prose-td-borders": "rgba(162, 173, 179, 0.16)",
           },
         },
         quoteless: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ const config = {
         "2vh": "120dvh",
       },
       colors: {
-        "google-ink": "#12110C",
+        "google-ink": "#1B1915",
         "google-paper": "#FFFFFF",
         "google-blue": "#1A73E8",
         "google-muted": "#BDC1C6",
@@ -29,7 +29,7 @@ const config = {
       },
       backgroundImage: {
         "nacre-moonlit":
-          "linear-gradient(135deg, #EDF7F3 0%, #9DF4E6 24%, #B7B9FF 52%, #F4B9DE 76%, #FFF4CA 100%)",
+          "linear-gradient(112deg, #FFFDF7 0%, #FFEAF4 8%, #F7CFE3 15%, #DCD6FF 24%, #C8DFFF 32%, #F7FFFF 41%, #FFF5EC 49%, #F4C8DC 58%, #DFD4FF 68%, #D7F3FF 77%, #FFF1E4 86%, #E8E9FF 94%, #FFFDF8 100%)",
       },
       fontFamily: {
         sans: ["LINE Seed Sans KR", "system-ui", "sans-serif"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,8 +24,8 @@ const config = {
         "google-blue": "#A2ADB3",
         "google-muted": "#8B9290",
         "google-yellow": "#8D8173",
-        "gradient-start": "#E8ECEC",
-        "gradient-end": "#C8D1D2",
+        "gradient-start": "#F8FBFB",
+        "gradient-end": "#A2ADB3",
         "mineral-ink": "#070707",
         "mineral-soot": "#020303",
         "mineral-graphite": "#101211",
@@ -43,7 +43,7 @@ const config = {
         "mineral-wash":
           "linear-gradient(112deg, #0A0B0A 0%, #101211 48%, #080909 100%)",
         "mineral-lettering":
-          "linear-gradient(112deg, #E8ECEC 0%, #DDE2E2 52%, #EEF1F0 100%)",
+          "linear-gradient(112deg, #F8FBFB 0%, #D4E5EC 24%, #A2ADB3 48%, #E5EEF1 72%, #FFFFFF 100%)",
         "mineral-canvas":
           "radial-gradient(circle at 78% 12%, rgb(31 42 40 / 0.12), transparent 28%), radial-gradient(circle at 12% 84%, rgb(32 38 50 / 0.1), transparent 30%), linear-gradient(145deg, #070707 0%, #030404 48%, #0C0D0C 100%)",
         "mineral-brush":


### PR DESCRIPTION
## 요약

- 자개 실험은 보존하고 Mineral Wash 중심의 블로그 테마와 전역 구아슈 배경을 적용함
- 색상 테스트 페이지를 정리하고 Blue Steel 하이라이트 및 붓칠 hover 인터랙션을 추가함
- 테스트 라우트를 개발 환경 전용으로 제한함

### Mineral Wash 테마 적용

- 검은 graphite 표면, 차가운 silver-blue 텍스트, 낮은 농도의 fixed 구아슈 배경을 전역 UI에 적용함.
- 헤더, 글 상세, 카드, 포트폴리오, 코드 표면의 강조색을 같은 톤으로 정리함.

### 테스트 페이지와 하이라이트

- 자개, 구아슈, 컬러 테스트 페이지를 실험과 기준 확인용으로 구성함.
- Blue Steel 하이라이트 후보를 선택하고 hover 시 붓칠 stroke가 그려지는 인터랙션을 추가함.

### 테스트 라우트 제한

- 테스트 라우트가 production export 결과에 남지 않도록 개발 환경 전용 처리 흐름을 추가함.

### 검증

- `pnpm lint`
- `pnpm build`