### PR TITLE
style: 구아슈 배경 포인트 농도 조정

### DIFF
--- a/src/app/test/gouache/gouache.module.css
+++ b/src/app/test/gouache/gouache.module.css
@@ -52,18 +52,18 @@
 }
 
 .lacquerBloom {
-  left: -20%;
-  bottom: -40%;
+  left: -24%;
+  bottom: -30%;
   z-index: 3;
-  width: 68%;
-  height: 58%;
-  opacity: 0.5;
+  width: 66%;
+  height: 66%;
+  opacity: 0.32;
   background:
-    radial-gradient(ellipse at 38% 50%, rgb(0 0 0 / 0.78) 0 22%, rgb(31 42 40 / 0.11) 44%, transparent 72%),
-    conic-gradient(from 224deg at 52% 54%, transparent 0 20%, rgb(32 38 50 / 0.14) 28% 38%, transparent 48% 100%);
-  border-radius: 54% 42% 56% 38%;
-  mix-blend-mode: multiply;
-  transform: rotate(-10deg) skewX(-6deg);
+    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.14) 0 10%, rgb(31 42 40 / 0.19) 28%, transparent 66%),
+    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.18) 25% 36%, rgb(232 236 236 / 0.08) 44% 52%, transparent 62% 100%);
+  border-radius: 50% 44% 58% 40%;
+  mix-blend-mode: screen;
+  transform: rotate(-16deg) skewX(-5deg);
 }
 
 .nacreVeil {
@@ -126,6 +126,23 @@
   height: 100%;
   pointer-events: none;
   background: linear-gradient(90deg, rgb(7 7 7 / 0.94) 0%, rgb(7 7 7 / 0.7) 58%, transparent 100%);
+}
+
+.readingField::after {
+  position: absolute;
+  left: -14%;
+  bottom: -12%;
+  width: min(50rem, 64vw);
+  height: min(30rem, 50vh);
+  pointer-events: none;
+  content: "";
+  opacity: 0.32;
+  background:
+    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.18) 0 10%, rgb(31 42 40 / 0.23) 30%, transparent 68%),
+    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.18) 27% 38%, rgb(232 236 236 / 0.08) 45% 52%, transparent 62% 100%);
+  filter: url("#gouache-bristle") blur(0.7px);
+  mix-blend-mode: screen;
+  transform: rotate(-14deg);
 }
 
 .strokeCard {

--- a/src/app/test/gouache/gouache.module.css
+++ b/src/app/test/gouache/gouache.module.css
@@ -57,10 +57,10 @@
   z-index: 3;
   width: 66%;
   height: 66%;
-  opacity: 0.32;
+  opacity: 0.46;
   background:
-    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.14) 0 10%, rgb(31 42 40 / 0.19) 28%, transparent 66%),
-    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.18) 25% 36%, rgb(232 236 236 / 0.08) 44% 52%, transparent 62% 100%);
+    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.2) 0 10%, rgb(31 42 40 / 0.32) 28%, transparent 66%),
+    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.3) 25% 36%, rgb(232 236 236 / 0.12) 44% 52%, transparent 62% 100%);
   border-radius: 50% 44% 58% 40%;
   mix-blend-mode: screen;
   transform: rotate(-16deg) skewX(-5deg);
@@ -72,10 +72,10 @@
   z-index: 4;
   width: 60%;
   height: 70%;
-  opacity: 0.34;
+  opacity: 0.44;
   background:
-    radial-gradient(ellipse at 42% 48%, rgb(232 236 236 / 0.16) 0 13%, rgb(31 42 40 / 0.2) 30%, transparent 64%),
-    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(162 173 179 / 0.14) 24% 31%, rgb(32 38 50 / 0.2) 38% 48%, transparent 58% 100%);
+    radial-gradient(ellipse at 42% 48%, rgb(232 236 236 / 0.2) 0 13%, rgb(31 42 40 / 0.3) 30%, transparent 64%),
+    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(162 173 179 / 0.2) 24% 31%, rgb(32 38 50 / 0.3) 38% 48%, transparent 58% 100%);
   border-radius: 44% 58% 40% 54%;
   mix-blend-mode: screen;
   transform: rotate(15deg) skewX(4deg);
@@ -136,10 +136,10 @@
   height: min(30rem, 50vh);
   pointer-events: none;
   content: "";
-  opacity: 0.32;
+  opacity: 0.48;
   background:
-    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.18) 0 10%, rgb(31 42 40 / 0.23) 30%, transparent 68%),
-    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.18) 27% 38%, rgb(232 236 236 / 0.08) 45% 52%, transparent 62% 100%);
+    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.24) 0 10%, rgb(31 42 40 / 0.34) 30%, transparent 68%),
+    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.3) 27% 38%, rgb(232 236 236 / 0.12) 45% 52%, transparent 62% 100%);
   filter: url("#gouache-bristle") blur(0.7px);
   mix-blend-mode: screen;
   transform: rotate(-14deg);

--- a/src/components/background/mineral-wash-background.module.css
+++ b/src/components/background/mineral-wash-background.module.css
@@ -57,10 +57,10 @@
   z-index: 3;
   width: 66%;
   height: 66%;
-  opacity: 0.32;
+  opacity: 0.46;
   background:
-    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.14) 0 10%, rgb(31 42 40 / 0.19) 28%, transparent 66%),
-    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.18) 25% 36%, rgb(232 236 236 / 0.08) 44% 52%, transparent 62% 100%);
+    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.2) 0 10%, rgb(31 42 40 / 0.32) 28%, transparent 66%),
+    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.3) 25% 36%, rgb(232 236 236 / 0.12) 44% 52%, transparent 62% 100%);
   border-radius: 50% 44% 58% 40%;
   mix-blend-mode: screen;
   transform: rotate(-16deg) skewX(-5deg);
@@ -72,10 +72,10 @@
   z-index: 4;
   width: 60%;
   height: 70%;
-  opacity: 0.34;
+  opacity: 0.44;
   background:
-    radial-gradient(ellipse at 42% 48%, rgb(232 236 236 / 0.16) 0 13%, rgb(31 42 40 / 0.2) 30%, transparent 64%),
-    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(162 173 179 / 0.14) 24% 31%, rgb(32 38 50 / 0.2) 38% 48%, transparent 58% 100%);
+    radial-gradient(ellipse at 42% 48%, rgb(232 236 236 / 0.2) 0 13%, rgb(31 42 40 / 0.3) 30%, transparent 64%),
+    conic-gradient(from 218deg at 44% 48%, transparent 0 18%, rgb(162 173 179 / 0.2) 24% 31%, rgb(32 38 50 / 0.3) 38% 48%, transparent 58% 100%);
   border-radius: 44% 58% 40% 54%;
   mix-blend-mode: screen;
   transform: rotate(15deg) skewX(4deg);
@@ -136,10 +136,10 @@
   height: min(30rem, 50vh);
   pointer-events: none;
   content: "";
-  opacity: 0.32;
+  opacity: 0.48;
   background:
-    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.18) 0 10%, rgb(31 42 40 / 0.23) 30%, transparent 68%),
-    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.18) 27% 38%, rgb(232 236 236 / 0.08) 45% 52%, transparent 62% 100%);
+    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.24) 0 10%, rgb(31 42 40 / 0.34) 30%, transparent 68%),
+    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.3) 27% 38%, rgb(232 236 236 / 0.12) 45% 52%, transparent 62% 100%);
   filter: url("#mineral-gouache-bristle") blur(0.7px);
   mix-blend-mode: screen;
   transform: rotate(-14deg);

--- a/src/components/background/mineral-wash-background.module.css
+++ b/src/components/background/mineral-wash-background.module.css
@@ -52,18 +52,18 @@
 }
 
 .lacquerBloom {
-  left: -20%;
-  bottom: -40%;
+  left: -24%;
+  bottom: -30%;
   z-index: 3;
-  width: 68%;
-  height: 58%;
-  opacity: 0.5;
+  width: 66%;
+  height: 66%;
+  opacity: 0.32;
   background:
-    radial-gradient(ellipse at 38% 50%, rgb(0 0 0 / 0.78) 0 22%, rgb(31 42 40 / 0.11) 44%, transparent 72%),
-    conic-gradient(from 224deg at 52% 54%, transparent 0 20%, rgb(32 38 50 / 0.14) 28% 38%, transparent 48% 100%);
-  border-radius: 54% 42% 56% 38%;
-  mix-blend-mode: multiply;
-  transform: rotate(-10deg) skewX(-6deg);
+    radial-gradient(ellipse at 46% 48%, rgb(162 173 179 / 0.14) 0 10%, rgb(31 42 40 / 0.19) 28%, transparent 66%),
+    conic-gradient(from 34deg at 42% 50%, transparent 0 18%, rgb(32 38 50 / 0.18) 25% 36%, rgb(232 236 236 / 0.08) 44% 52%, transparent 62% 100%);
+  border-radius: 50% 44% 58% 40%;
+  mix-blend-mode: screen;
+  transform: rotate(-16deg) skewX(-5deg);
 }
 
 .nacreVeil {
@@ -126,4 +126,21 @@
   height: 100%;
   pointer-events: none;
   background: linear-gradient(90deg, rgb(7 7 7 / 0.94) 0%, rgb(7 7 7 / 0.7) 58%, transparent 100%);
+}
+
+.readingField::after {
+  position: absolute;
+  left: -14%;
+  bottom: -12%;
+  width: min(50rem, 64vw);
+  height: min(30rem, 50vh);
+  pointer-events: none;
+  content: "";
+  opacity: 0.32;
+  background:
+    radial-gradient(ellipse at 44% 46%, rgb(162 173 179 / 0.18) 0 10%, rgb(31 42 40 / 0.23) 30%, transparent 68%),
+    conic-gradient(from 42deg at 43% 50%, transparent 0 20%, rgb(32 38 50 / 0.18) 27% 38%, rgb(232 236 236 / 0.08) 45% 52%, transparent 62% 100%);
+  filter: url("#mineral-gouache-bristle") blur(0.7px);
+  mix-blend-mode: screen;
+  transform: rotate(-14deg);
 }


### PR DESCRIPTION
## 요약

- 구아슈 배경의 좌하단과 우상단 포인트가 더 잘 보이도록 농도를 조정함
- 테스트 페이지와 전역 배경의 시각 기준을 동일하게 유지함

### 배경 포인트 보강

- 모서리 포인트의 투명도와 색 농도를 높여 어두운 배경에서도 질감이 드러나도록 조정함
- 읽기 영역의 가독성을 유지하면서 포인트가 너무 묻히지 않도록 균형을 맞춤