### PR TITLE
style: 메인 레이아웃 폭 조정

### DIFF
--- a/src/app/(blog-layout)/page.tsx
+++ b/src/app/(blog-layout)/page.tsx
@@ -13,7 +13,7 @@ const HomePage = () => {
         main
       />
       <section className="w-full bg-transparent px-6 py-16 text-google-paper">
-        <div className="mx-auto w-full max-w-[1632px]">
+        <div className="mx-auto w-full max-w-[1320px]">
           <div className="mb-14 flex flex-col gap-3 md:mb-20 md:flex-row md:items-end md:justify-between">
             <h2 className="text-4xl font-normal leading-tight text-current md:text-[64px] md:leading-[67px]">
               Latest Articles

--- a/src/app/(blog-layout)/tags/[tag]/page.tsx
+++ b/src/app/(blog-layout)/tags/[tag]/page.tsx
@@ -43,7 +43,7 @@ const TagPage = async ({ params }: ITagPageProps) => {
     <>
       <ContentHeader title={`TAG : ${tag}`} text="같은 맥락으로 묶인 글" main />
       <section className="w-full bg-transparent px-6 py-16 text-google-paper">
-        <div className="mx-auto w-full max-w-[1632px]">
+        <div className="mx-auto w-full max-w-[1320px]">
           <div className="mb-14 flex flex-col gap-3 md:mb-20 md:flex-row md:items-end md:justify-between">
             <h2 className="text-4xl font-normal leading-tight text-current md:text-[64px] md:leading-[67px]">
               Tagged Articles

--- a/src/components/content-header/content-header.tsx
+++ b/src/components/content-header/content-header.tsx
@@ -91,7 +91,7 @@ const ContentHeader = ({
           : "pb-16 pt-24 md:pb-24 md:pt-[126px]"
       )}
     >
-      <div className="mx-auto w-full max-w-[1632px]">
+      <div className="mx-auto w-full max-w-[1320px]">
         <ContentHeaderMotionText className="w-full">
           {date && (
             <ContentHeaderMotionItem className="font-mono text-xs uppercase leading-none tracking-normal text-current md:text-base">


### PR DESCRIPTION
## 요약

- 메인 글 목록의 최대 폭을 줄여 큰 화면에서 카드가 과하게 넓어지지 않도록 조정함
- 메인 헤더 영역을 글 목록과 같은 폭으로 맞춰 화면 정렬감을 개선함

### 글 목록 폭 조정

- 큰 화면에서 목록 카드가 화면을 지나치게 넓게 차지하지 않도록 최대 폭을 줄임.
- 태그별 목록도 동일한 폭 기준을 사용하도록 맞춤.

### 헤더 정렬 조정

- 메인 헤더의 텍스트 영역이 글 목록과 같은 기준선에서 시작하도록 폭을 통일함.