### PR TITLE
feat: 메타데이터 SEO 정리

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,8 +10,8 @@
     "en": "EN"
   },
   "HomePage": {
-    "heroTitle": "Insights",
-    "heroText": "Notes from hands-on exploration, tradeoffs, and problems worth remembering.",
+    "heroTitle": "Hindsight",
+    "heroText": "Only Clear Later",
     "latestArticles": "Latest Articles",
     "postCount": "{count, plural, =0 {0 posts} one {# post} other {# posts}}"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,7 +22,7 @@
     "postCount": "{count, plural, =0 {0 posts} one {# post} other {# posts}}"
   },
   "AboutPage": {
-    "title": "ABOUT | ou9999.dev",
+    "title": "ABOUT | OU9999",
     "paragraph1": "My mother is the kind of person who improves even the smallest inconvenient things. That has always stayed with me. Even in a different field, I feel I share a similar instinct.",
     "paragraph2": "My parents watched me more than they judged me. Growing up with that kind of attention made it feel natural to love the world as it is.",
     "profile": "Yujin Oh﹒FrontEnd Developer"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -10,8 +10,8 @@
     "en": "EN"
   },
   "HomePage": {
-    "heroTitle": "Insights",
-    "heroText": "노력과 고민을 담아 기록한 글",
+    "heroTitle": "Hindsight",
+    "heroText": "Only Clear Later",
     "latestArticles": "Latest Articles",
     "postCount": "{count, plural, =0 {0 posts} one {# post} other {# posts}}"
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -22,7 +22,7 @@
     "postCount": "{count, plural, =0 {0 posts} one {# post} other {# posts}}"
   },
   "AboutPage": {
-    "title": "ABOUT | ou9999.dev",
+    "title": "ABOUT | OU9999",
     "paragraph1": "어머니가 작고 사소한 일이라도 불편한 부분이 있다면 개선하시는 사람이라는 것. 그것은 나에게 특별한 감정을 불러일으킨다. 다른 분야일지라도, 나는 어머니와 비슷한 부분이 많다고 느낀다.",
     "paragraph2": "부모님은 아들을 평가하시기보다는 감상하셨다. 감상을 우선으로 받고 자랐기에, 있는 그대로의 세상을 사랑하는 건 어쩌면 당연했던 것 같다.",
     "profile": "오유진﹒FrontEnd Developer"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
-disallow: /imgs
-disallow: /about
-allow: /
-sitemap: https://ou9999-dev.com/sitemap.xml
+Allow: /
+Sitemap: https://ou9999-dev.com/sitemap.xml

--- a/src/app/(ko)/(about-layout)/about/page.tsx
+++ b/src/app/(ko)/(about-layout)/about/page.tsx
@@ -1,10 +1,13 @@
 import { AboutMe } from "@/components/main-section/about-me";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import { defaultLocale } from "@/i18n/config";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "ABOUT | ou9999.dev",
-};
+export const metadata: Metadata = createPageMetadata({
+  title: `ABOUT | ${siteTitle}`,
+  locale: defaultLocale,
+  pathname: "/about",
+});
 
 const AboutPage = () => {
   return <AboutMe locale={defaultLocale} />;

--- a/src/app/(ko)/(about-layout)/popover/page.tsx
+++ b/src/app/(ko)/(about-layout)/popover/page.tsx
@@ -1,10 +1,13 @@
 import { MobilePopover } from "@/components/nav/mobile-popover";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import { defaultLocale } from "@/i18n/config";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "MENU | ou9999.dev",
-};
+export const metadata: Metadata = createPageMetadata({
+  title: `MENU | ${siteTitle}`,
+  locale: defaultLocale,
+  pathname: "/popover",
+});
 
 const MobilePopoverPage = () => {
   return <MobilePopover locale={defaultLocale} />;

--- a/src/app/(ko)/(blog-layout)/p/[title]/page.tsx
+++ b/src/app/(ko)/(blog-layout)/p/[title]/page.tsx
@@ -8,6 +8,7 @@ import {
   type PostParams,
 } from "@/utils/post-util";
 import { defaultLocale } from "@/i18n/config";
+import { createPostMetadata, siteTitle } from "@/constant/meta-data";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -24,20 +25,18 @@ export const generateMetadata = async ({
     return {};
   }
 
-  const title = `${post.title} | ou9999.dev`;
+  const title = `${post.title} | ${siteTitle}`;
   const thumbnail = `/imgs/openGraph/${post.thumbnail}.png`;
 
-  return {
+  return createPostMetadata({
     title,
     description: post.description,
-    openGraph: {
-      title,
-      description: post.description,
-      images: {
-        url: thumbnail,
-      },
-    },
-  };
+    image: thumbnail,
+    locale: defaultLocale,
+    pathname: `/p/${post.slugAsParams}`,
+    publishedTime: post.date,
+    tags: post.tags,
+  });
 };
 
 export const generateStaticParams = async (): Promise<PostParams[]> => {

--- a/src/app/(ko)/(blog-layout)/tags/[tag]/page.tsx
+++ b/src/app/(ko)/(blog-layout)/tags/[tag]/page.tsx
@@ -6,6 +6,7 @@ import {
   type TagParams,
 } from "@/utils/post-util";
 import { defaultLocale } from "@/i18n/config";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
@@ -16,12 +17,14 @@ interface ITagPageProps {
 export const generateMetadata = async ({
   params,
 }: ITagPageProps): Promise<Metadata> => {
-  const slug = decodeURI((await params).tag);
-  const title = `${slug.toUpperCase()} | ou9999.dev`;
+  const slug = decodeURIComponent((await params).tag);
+  const title = `${slug.toUpperCase()} | ${siteTitle}`;
 
-  return {
+  return createPageMetadata({
     title,
-  };
+    locale: defaultLocale,
+    pathname: `/tags/${encodeURIComponent(slug)}`,
+  });
 };
 
 export const generateStaticParams = async (): Promise<TagParams[]> => {

--- a/src/app/(ko)/layout.tsx
+++ b/src/app/(ko)/layout.tsx
@@ -4,11 +4,11 @@ import { setRequestLocale } from "next-intl/server";
 import "@kfonts/line-seed-sans-kr/index.css";
 import "@/css/tailwind.css";
 import "@/css/prettyCode.css";
-import { siteMetadata } from "@/constant/meta-data";
+import { createSiteMetadata } from "@/constant/meta-data";
 import { SiteShell } from "@/components/layout/site-shell";
 import { defaultLocale } from "@/i18n/config";
 
-export const metadata: Metadata = siteMetadata;
+export const metadata: Metadata = createSiteMetadata(defaultLocale);
 
 const RootLayout = ({
   children,

--- a/src/app/(ko)/test/color/page.tsx
+++ b/src/app/(ko)/test/color/page.tsx
@@ -4,7 +4,7 @@ import { HighlightBrushText } from "./highlight-brush-text";
 import styles from "./color.module.css";
 
 export const metadata: Metadata = {
-  title: "Color Test | ou9999.dev",
+  title: "Color Test | OU9999",
   description: "Mineral Wash color reference page",
 };
 

--- a/src/app/(ko)/test/gouache/page.tsx
+++ b/src/app/(ko)/test/gouache/page.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/utils/tailwind-util";
 import styles from "./gouache.module.css";
 
 export const metadata: Metadata = {
-  title: "Gouache Test | ou9999.dev",
+  title: "Gouache Test | OU9999",
   description: "Mineral Wash gouache layer test page",
 };
 

--- a/src/app/(ko)/test/jagae/page.tsx
+++ b/src/app/(ko)/test/jagae/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { cn } from "@/utils/tailwind-util";
 
 export const metadata: Metadata = {
-  title: "Jagae Test | ou9999.dev",
+  title: "Jagae Test | OU9999",
   description: "Nacre gradient test page",
 };
 

--- a/src/app/en/(about-layout)/about/page.tsx
+++ b/src/app/en/(about-layout)/about/page.tsx
@@ -1,9 +1,12 @@
 import { AboutMe } from "@/components/main-section/about-me";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "ABOUT | ou9999.dev",
-};
+export const metadata: Metadata = createPageMetadata({
+  title: `ABOUT | ${siteTitle}`,
+  locale: "en",
+  pathname: "/about",
+});
 
 const AboutPage = () => {
   return <AboutMe locale="en" />;

--- a/src/app/en/(about-layout)/popover/page.tsx
+++ b/src/app/en/(about-layout)/popover/page.tsx
@@ -1,9 +1,12 @@
 import { MobilePopover } from "@/components/nav/mobile-popover";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "MENU | ou9999.dev",
-};
+export const metadata: Metadata = createPageMetadata({
+  title: `MENU | ${siteTitle}`,
+  locale: "en",
+  pathname: "/popover",
+});
 
 const MobilePopoverPage = () => {
   return <MobilePopover locale="en" />;

--- a/src/app/en/(blog-layout)/p/[title]/page.tsx
+++ b/src/app/en/(blog-layout)/p/[title]/page.tsx
@@ -7,6 +7,7 @@ import {
   getPostFromParamsBySlug,
   type PostParams,
 } from "@/utils/post-util";
+import { createPostMetadata, siteTitle } from "@/constant/meta-data";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -23,20 +24,18 @@ export const generateMetadata = async ({
     return {};
   }
 
-  const title = `${post.title} | ou9999.dev`;
+  const title = `${post.title} | ${siteTitle}`;
   const thumbnail = `/imgs/openGraph/${post.thumbnail}.png`;
 
-  return {
+  return createPostMetadata({
     title,
     description: post.description,
-    openGraph: {
-      title,
-      description: post.description,
-      images: {
-        url: thumbnail,
-      },
-    },
-  };
+    image: thumbnail,
+    locale: "en",
+    pathname: `/p/${post.slugAsParams}`,
+    publishedTime: post.date,
+    tags: post.tags,
+  });
 };
 
 export const generateStaticParams = async (): Promise<PostParams[]> => {

--- a/src/app/en/(blog-layout)/tags/[tag]/page.tsx
+++ b/src/app/en/(blog-layout)/tags/[tag]/page.tsx
@@ -6,6 +6,7 @@ import {
   getPostsFromParamsByTag,
   type TagParams,
 } from "@/utils/post-util";
+import { createPageMetadata, siteTitle } from "@/constant/meta-data";
 import type { Metadata } from "next";
 
 interface ITagPageProps {
@@ -15,12 +16,14 @@ interface ITagPageProps {
 export const generateMetadata = async ({
   params,
 }: ITagPageProps): Promise<Metadata> => {
-  const slug = decodeURI((await params).tag);
-  const title = `${slug.toUpperCase()} | ou9999.dev`;
+  const slug = decodeURIComponent((await params).tag);
+  const title = `${slug.toUpperCase()} | ${siteTitle}`;
 
-  return {
+  return createPageMetadata({
     title,
-  };
+    locale: "en",
+    pathname: `/tags/${encodeURIComponent(slug)}`,
+  });
 };
 
 export const generateStaticParams = async (): Promise<TagParams[]> => {

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -4,10 +4,10 @@ import { setRequestLocale } from "next-intl/server";
 import "@kfonts/line-seed-sans-kr/index.css";
 import "@/css/tailwind.css";
 import "@/css/prettyCode.css";
-import { siteMetadata } from "@/constant/meta-data";
+import { createSiteMetadata } from "@/constant/meta-data";
 import { SiteShell } from "@/components/layout/site-shell";
 
-export const metadata: Metadata = siteMetadata;
+export const metadata: Metadata = createSiteMetadata("en");
 
 const RootLayout = ({
   children,

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,5 +1,5 @@
 import { myDomain } from "@/constant/domain";
-import { defaultDescription } from "@/constant/meta-data";
+import { defaultDescription, siteTitle } from "@/constant/meta-data";
 import { getLocalizedPath } from "@/i18n/config";
 import { getAllPosts } from "@/utils/post-util";
 import RSS from "rss";
@@ -12,7 +12,7 @@ export const GET = async (): Promise<Response> => {
   });
 
   const feed = new RSS({
-    title: "ou9999.dev",
+    title: siteTitle,
     description: defaultDescription,
     site_url: myDomain,
     feed_url: `${myDomain}/feed.xml`,

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,4 +1,5 @@
 import { myDomain } from "@/constant/domain";
+import { defaultDescription } from "@/constant/meta-data";
 import { getLocalizedPath } from "@/i18n/config";
 import { getAllPosts } from "@/utils/post-util";
 import RSS from "rss";
@@ -12,7 +13,7 @@ export const GET = async (): Promise<Response> => {
 
   const feed = new RSS({
     title: "ou9999.dev",
-    description: "OU9999's blog",
+    description: defaultDescription,
     site_url: myDomain,
     feed_url: `${myDomain}/feed.xml`,
     copyright: "@ou9999",

--- a/src/constant/meta-data.ts
+++ b/src/constant/meta-data.ts
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { defaultLocale, getLocalizedPath, locales, type AppLocale } from "@/i18n/config";
 import { myDomain } from "./domain";
 
-const siteTitle = "ou9999.dev";
+const siteTitle = "OU9999";
 const defaultDescription = "Only Clear in Hindsight";
 const defaultOpenGraphImage = "/imgs/openGraph/default-og.png";
 const twitterAccount = "@OU9999";

--- a/src/constant/meta-data.ts
+++ b/src/constant/meta-data.ts
@@ -1,51 +1,220 @@
 import type { Metadata } from "next";
-import { OpenGraph } from "next/dist/lib/metadata/types/opengraph-types";
-import { Twitter } from "next/dist/lib/metadata/types/twitter-types";
+import { defaultLocale, getLocalizedPath, locales, type AppLocale } from "@/i18n/config";
 import { myDomain } from "./domain";
 
-const defaultTitle = "ou9999.dev";
-const defaultDescription =
-  "직접 탐구하고 겪었던 문제점과 개선점을 공유하는 글을 작성하는 블로그입니다.";
+const siteTitle = "ou9999.dev";
+const defaultDescription = "Only Clear in Hindsight";
 const defaultOpenGraphImage = "/imgs/openGraph/default-og.png";
+const twitterAccount = "@OU9999";
 
-const defaultOpenGraph: OpenGraph = {
-  type: "website",
-  title: defaultTitle,
-  description: defaultDescription,
-  images: {
-    url: defaultOpenGraphImage,
-    width: 1200,
-    height: 630,
-  },
+interface PageMetadataParams {
+  title?: string;
+  description?: string;
+  image?: string;
+  locale?: AppLocale;
+  pathname?: string;
+}
+
+interface PostMetadataParams extends PageMetadataParams {
+  publishedTime: string;
+  tags: string[];
+}
+
+const openGraphLocales: Record<AppLocale, string> = {
+  ko: "ko_KR",
+  en: "en_US",
 };
 
-const defaultTwitter: Twitter = {
-  card: "summary_large_image",
-  site: "@OU9999",
-  title: defaultTitle,
-  description: defaultDescription,
-  images: [defaultOpenGraphImage],
-};
-
-const siteMetadata: Metadata = {
-  metadataBase: new URL(myDomain),
-  title: "ou9999.dev",
-  description: "OU9999's blog",
-  icons: {
-    icon: "/favicon.ico",
-  },
-  openGraph: {
-    ...defaultOpenGraph,
-  },
-  twitter: {
-    ...defaultTwitter,
-  },
-  verification: {
-    google: "c08fG67rRWvc_6yY5wNMLhl__pmClidB0MxV4N-GLIw",
-    other: {
-      "naver-site-verification": "064760e130b51b3bf3bd7c0f24aa0d3892199f1f",
+const createAlternates = (
+  locale: AppLocale,
+  pathname: string
+): Metadata["alternates"] => {
+  return {
+    canonical: getLocalizedPath(locale, pathname),
+    languages: {
+      ko: getLocalizedPath("ko", pathname),
+      en: getLocalizedPath("en", pathname),
+      "x-default": getLocalizedPath(defaultLocale, pathname),
     },
-  },
+  };
 };
 
-export { defaultOpenGraph, defaultTwitter, siteMetadata };
+const getAlternateOpenGraphLocales = (locale: AppLocale) => {
+  return locales
+    .filter((alternateLocale) => alternateLocale !== locale)
+    .map((alternateLocale) => openGraphLocales[alternateLocale]);
+};
+
+const createWebsiteOpenGraph = ({
+  title = siteTitle,
+  description = defaultDescription,
+  image = defaultOpenGraphImage,
+  locale = defaultLocale,
+  pathname = "/",
+}: PageMetadataParams): Metadata["openGraph"] => {
+  return {
+    type: "website",
+    title,
+    description,
+    url: getLocalizedPath(locale, pathname),
+    siteName: siteTitle,
+    locale: openGraphLocales[locale],
+    alternateLocale: getAlternateOpenGraphLocales(locale),
+    images: {
+      url: image,
+      width: 1200,
+      height: 630,
+      alt: title,
+    },
+  };
+};
+
+const createArticleOpenGraph = ({
+  title = siteTitle,
+  description = defaultDescription,
+  image = defaultOpenGraphImage,
+  locale = defaultLocale,
+  pathname = "/",
+  publishedTime,
+  tags,
+}: PostMetadataParams): Metadata["openGraph"] => {
+  return {
+    type: "article",
+    title,
+    description,
+    url: getLocalizedPath(locale, pathname),
+    siteName: siteTitle,
+    locale: openGraphLocales[locale],
+    alternateLocale: getAlternateOpenGraphLocales(locale),
+    publishedTime,
+    tags,
+    images: {
+      url: image,
+      width: 1200,
+      height: 630,
+      alt: title,
+    },
+  };
+};
+
+const createTwitter = ({
+  title = siteTitle,
+  description = defaultDescription,
+  image = defaultOpenGraphImage,
+}: PageMetadataParams): Metadata["twitter"] => {
+  return {
+    card: "summary_large_image",
+    site: twitterAccount,
+    creator: twitterAccount,
+    title,
+    description,
+    images: {
+      url: image,
+      alt: title,
+    },
+  };
+};
+
+const createPageMetadata = ({
+  title = siteTitle,
+  description = defaultDescription,
+  image = defaultOpenGraphImage,
+  locale = defaultLocale,
+  pathname = "/",
+}: PageMetadataParams = {}): Metadata => {
+  return {
+    title,
+    description,
+    alternates: createAlternates(locale, pathname),
+    openGraph: createWebsiteOpenGraph({
+      title,
+      description,
+      image,
+      locale,
+      pathname,
+    }),
+    twitter: createTwitter({
+      title,
+      description,
+      image,
+    }),
+  };
+};
+
+const createPostMetadata = ({
+  title,
+  description = defaultDescription,
+  image = defaultOpenGraphImage,
+  locale = defaultLocale,
+  pathname = "/",
+  publishedTime,
+  tags,
+}: PostMetadataParams): Metadata => {
+  return {
+    title,
+    description,
+    alternates: createAlternates(locale, pathname),
+    openGraph: createArticleOpenGraph({
+      title,
+      description,
+      image,
+      locale,
+      pathname,
+      publishedTime,
+      tags,
+    }),
+    twitter: createTwitter({
+      title,
+      description,
+      image,
+    }),
+  };
+};
+
+const createSiteMetadata = (locale: AppLocale = defaultLocale): Metadata => {
+  return {
+    metadataBase: new URL(myDomain),
+    applicationName: siteTitle,
+    authors: {
+      name: "Yujin Oh",
+    },
+    creator: "Yujin Oh",
+    publisher: siteTitle,
+    robots: {
+      index: true,
+      follow: true,
+    },
+    icons: {
+      icon: [
+        {
+          url: "/favicon.ico",
+          sizes: "256x256",
+        },
+        {
+          url: "/favicon.png",
+          sizes: "1254x1254",
+          type: "image/png",
+        },
+      ],
+    },
+    ...createPageMetadata({
+      locale,
+      pathname: "/",
+    }),
+    verification: {
+      google: "c08fG67rRWvc_6yY5wNMLhl__pmClidB0MxV4N-GLIw",
+      other: {
+        "naver-site-verification": "064760e130b51b3bf3bd7c0f24aa0d3892199f1f",
+      },
+    },
+  };
+};
+
+export {
+  createPageMetadata,
+  createPostMetadata,
+  createSiteMetadata,
+  defaultDescription,
+  defaultOpenGraphImage,
+  siteTitle,
+};


### PR DESCRIPTION
## 요약

- 메인 헤더 카피와 사이트 제목 표기를 새 브랜드 톤에 맞춰 정리함
- 공유 및 검색용 metadata를 페이지별 정보에 맞게 보강함
- RSS와 크롤러 접근 정책을 metadata 노출 의도에 맞게 조정함

### 브랜드 표기 정리

- 메인 화면 카피를 Hindsight 흐름으로 맞추고, 사이트 제목 표기를 OU9999로 통일함.

### Metadata 보강

- 페이지별 제목과 설명이 공유 카드에 일관되게 반영되도록 정리함.
- 언어별 대체 링크와 대표 URL 정보를 추가해 검색 엔진이 페이지 관계를 이해하기 쉽게 함.

### 크롤링 정책 정리

- 대표 이미지와 공개 페이지가 크롤러 정책과 충돌하지 않도록 허용 범위를 정리함.
- 피드 제목도 사이트 표기와 같은 기준으로 맞춤.