### PR TITLE
feat: 헤더 모바일 메뉴와 브러시 내비게이션 추가

### DIFF
--- a/src/components/nav/header/header-nav-link.tsx
+++ b/src/components/nav/header/header-nav-link.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/utils/tailwind-util";
 import {
+  headerNavActiveBrushTintClassName,
   headerNavActiveBrushUnderlineClassName,
-  headerNavActiveTextClassName,
   headerNavBrushUnderlineClassName,
   headerNavLinkClassName,
   headerNavTextClassName,
@@ -26,14 +26,7 @@ const HeaderNavLink = ({ href, label }: HeaderNavLinkProps) => {
       aria-current={isActive ? "page" : undefined}
       className={headerNavLinkClassName}
     >
-      <span
-        className={cn(
-          headerNavTextClassName,
-          isActive && headerNavActiveTextClassName
-        )}
-      >
-        {label}
-      </span>
+      <span className={headerNavTextClassName}>{label}</span>
       <span
         aria-hidden="true"
         className={cn(
@@ -41,6 +34,12 @@ const HeaderNavLink = ({ href, label }: HeaderNavLinkProps) => {
           isActive && headerNavActiveBrushUnderlineClassName
         )}
       />
+      {isActive && (
+        <span
+          aria-hidden="true"
+          className={headerNavActiveBrushTintClassName}
+        />
+      )}
     </Link>
   );
 };

--- a/src/components/nav/header/header-nav-link.tsx
+++ b/src/components/nav/header/header-nav-link.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/utils/tailwind-util";
+import {
+  headerNavActiveBrushUnderlineClassName,
+  headerNavActiveTextClassName,
+  headerNavBrushUnderlineClassName,
+  headerNavLinkClassName,
+  headerNavTextClassName,
+} from "./header-nav-styles";
+
+interface HeaderNavLinkProps {
+  href: string;
+  label: string;
+}
+
+const HeaderNavLink = ({ href, label }: HeaderNavLinkProps) => {
+  const pathname = usePathname();
+  const isActive = pathname === href;
+
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={headerNavLinkClassName}
+    >
+      <span
+        className={cn(
+          headerNavTextClassName,
+          isActive && headerNavActiveTextClassName
+        )}
+      >
+        {label}
+      </span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          headerNavBrushUnderlineClassName,
+          isActive && headerNavActiveBrushUnderlineClassName
+        )}
+      />
+    </Link>
+  );
+};
+
+export { HeaderNavLink };

--- a/src/components/nav/header/header-nav-styles.ts
+++ b/src/components/nav/header/header-nav-styles.ts
@@ -1,0 +1,20 @@
+const headerNavLinkClassName =
+  "group relative inline-flex h-10 min-w-10 items-center justify-center px-1 pb-1 pt-2 outline-none";
+
+const headerNavTextClassName =
+  "relative z-10 translate-y-px font-brand text-xl font-normal leading-none text-google-paper transition-colors duration-200 group-hover:text-mineral-blue group-focus-visible:text-mineral-blue";
+
+const headerNavActiveTextClassName = "text-mineral-blue";
+
+const headerNavBrushUnderlineClassName =
+  "pointer-events-none absolute -bottom-2 left-1/2 h-[10px] w-[118%] -translate-x-1/2 bg-[url('/imgs/header/home-brush-hard-chalk-steel-v1.png')] bg-[length:100%_100%] bg-center bg-no-repeat opacity-0 md:-bottom-3 md:h-3";
+
+const headerNavActiveBrushUnderlineClassName = "opacity-82";
+
+export {
+  headerNavActiveBrushUnderlineClassName,
+  headerNavActiveTextClassName,
+  headerNavBrushUnderlineClassName,
+  headerNavLinkClassName,
+  headerNavTextClassName,
+};

--- a/src/components/nav/header/header-nav-styles.ts
+++ b/src/components/nav/header/header-nav-styles.ts
@@ -4,16 +4,18 @@ const headerNavLinkClassName =
 const headerNavTextClassName =
   "relative z-10 translate-y-px font-brand text-xl font-normal leading-none text-google-paper transition-colors duration-200 group-hover:text-mineral-blue group-focus-visible:text-mineral-blue";
 
-const headerNavActiveTextClassName = "text-mineral-blue";
-
 const headerNavBrushUnderlineClassName =
-  "pointer-events-none absolute -bottom-2 left-1/2 h-[10px] w-[118%] -translate-x-1/2 bg-[url('/imgs/header/home-brush-hard-chalk-steel-v1.png')] bg-[length:100%_100%] bg-center bg-no-repeat opacity-0 md:-bottom-3 md:h-3";
+  "pointer-events-none absolute -bottom-2 left-1/2 h-[10px] w-[118%] -translate-x-1/2 bg-[url('/imgs/header/home-brush-hard-chalk-steel-v1.png')] bg-[length:100%_100%] bg-center bg-no-repeat opacity-0 transition-opacity duration-200 md:-bottom-3 md:h-3";
 
-const headerNavActiveBrushUnderlineClassName = "opacity-82";
+const headerNavActiveBrushUnderlineClassName =
+  "opacity-82 group-hover:opacity-0 group-focus-visible:opacity-0";
+
+const headerNavActiveBrushTintClassName =
+  "pointer-events-none absolute -bottom-2 left-1/2 h-[10px] w-[118%] -translate-x-1/2 bg-mineral-blue opacity-0 transition-opacity duration-200 [mask-image:url('/imgs/header/home-brush-hard-chalk-steel-v1.png')] [mask-position:center] [mask-repeat:no-repeat] [mask-size:100%_100%] [-webkit-mask-image:url('/imgs/header/home-brush-hard-chalk-steel-v1.png')] [-webkit-mask-position:center] [-webkit-mask-repeat:no-repeat] [-webkit-mask-size:100%_100%] group-hover:opacity-82 group-focus-visible:opacity-82 md:-bottom-3 md:h-3";
 
 export {
+  headerNavActiveBrushTintClassName,
   headerNavActiveBrushUnderlineClassName,
-  headerNavActiveTextClassName,
   headerNavBrushUnderlineClassName,
   headerNavLinkClassName,
   headerNavTextClassName,

--- a/src/components/nav/header/locale-switch-link.tsx
+++ b/src/components/nav/header/locale-switch-link.tsx
@@ -2,18 +2,19 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { hoverMineralTextGradient } from "@/components/common/styles";
+import {
+  headerNavLinkClassName,
+  headerNavTextClassName,
+} from "@/components/nav/header/header-nav-styles";
 import {
   defaultLocale,
   getLocalizedPath,
   type AppLocale,
 } from "@/i18n/config";
-import { cn } from "@/utils/tailwind-util";
 
 interface LocaleSwitchLinkProps {
   label: string;
   locale: AppLocale;
-  variant?: "text" | "stamp";
 }
 
 const translatablePaths = new Set(["/", "/about", "/popover"]);
@@ -55,47 +56,17 @@ const getLocaleSwitchHref = (
 const LocaleSwitchLink = ({
   label,
   locale,
-  variant = "text",
 }: LocaleSwitchLinkProps) => {
   const pathname = usePathname();
   const localeSwitchHref = getLocaleSwitchHref(locale, pathname);
-
-  if (variant === "stamp") {
-    return (
-      <Link
-        href={localeSwitchHref}
-        lang="en"
-        className="group relative isolate flex min-h-10 min-w-[62px] items-center justify-center px-4 py-1 font-brand text-xl font-normal uppercase leading-none text-mineral-soot transition-opacity hover:opacity-90"
-      >
-        <svg
-          aria-hidden="true"
-          className="absolute inset-0 -z-10 h-full w-full overflow-visible"
-          focusable="false"
-          preserveAspectRatio="none"
-          viewBox="0 0 62 40"
-        >
-          <image
-            href="/imgs/header/header-locale-stamp-reference.svg"
-            height="40"
-            preserveAspectRatio="none"
-            width="62"
-          />
-        </svg>
-        <span className="relative z-10">{label}</span>
-      </Link>
-    );
-  }
 
   return (
     <Link
       href={localeSwitchHref}
       lang="en"
-      className={cn(
-        "text-lg font-semibold uppercase text-google-paper",
-        hoverMineralTextGradient
-      )}
+      className={headerNavLinkClassName}
     >
-      {label}
+      <span className={headerNavTextClassName}>{label}</span>
     </Link>
   );
 };

--- a/src/components/nav/header/popover-button.tsx
+++ b/src/components/nav/header/popover-button.tsx
@@ -1,4 +1,10 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { XIcon } from "@/components/svg/x-icon";
 import {
   defaultLocale,
   getLocalizedPath,
@@ -6,20 +12,178 @@ import {
 } from "@/i18n/config";
 
 interface PopoverButtonProps {
-  label: string;
-  locale?: AppLocale;
+  aboutLabel: string;
+  aboutHref: string;
+  closeLabel: string;
+  homeHref: string;
+  homeLabel: string;
+  locale: AppLocale;
+  localeSwitchLabel: string;
+  menuLabel: string;
+  openLabel: string;
+  tagLabel: string;
+  tags: MobileMenuTag[];
 }
 
+interface MobileMenuTag {
+  tag: string;
+  count: number;
+}
+
+interface MobileMenuLinkProps {
+  href: string;
+  lang?: string;
+  onClick: () => void;
+  text: string;
+}
+
+interface TagItemProps {
+  count: number;
+  locale: AppLocale;
+  onClick: () => void;
+  title: string;
+}
+
+const mobileMenuPanelId = "mobile-menu-panel";
+const translatablePaths = new Set(["/", "/about", "/popover"]);
+
+const getPathWithoutLocale = (pathname: string): string => {
+  if (pathname === "/en") {
+    return "/";
+  }
+
+  if (pathname.startsWith("/en/")) {
+    return pathname.slice(3);
+  }
+
+  return pathname;
+};
+
+const canPreservePath = (pathname: string): boolean => {
+  return (
+    translatablePaths.has(pathname) ||
+    pathname.startsWith("/p/") ||
+    pathname.startsWith("/tags/")
+  );
+};
+
+const getLocaleSwitchHref = (
+  locale: AppLocale,
+  pathname: string
+): string => {
+  const targetLocale = locale === defaultLocale ? "en" : defaultLocale;
+  const pathWithoutLocale = getPathWithoutLocale(pathname);
+
+  if (!canPreservePath(pathWithoutLocale)) {
+    return getLocalizedPath(targetLocale, "/");
+  }
+
+  return getLocalizedPath(targetLocale, pathWithoutLocale);
+};
+
+const MobileMenuLink = ({
+  href,
+  lang,
+  onClick,
+  text,
+}: MobileMenuLinkProps) => {
+  return (
+    <Link
+      href={href}
+      lang={lang}
+      className="font-brand text-[32px] font-normal leading-none text-google-paper/86 transition-colors hover:text-mineral-blue"
+      onClick={onClick}
+    >
+      {text}
+    </Link>
+  );
+};
+
+const TagItem = ({ count, locale, onClick, title }: TagItemProps) => {
+  return (
+    <Link
+      href={getLocalizedPath(locale, "/tags/" + encodeURIComponent(title))}
+      className="group inline-flex items-baseline gap-2 px-2 py-1 font-brand leading-none text-google-paper/58 transition-colors hover:text-mineral-blue"
+      onClick={onClick}
+    >
+      <span className="text-lg uppercase">{title}</span>
+      <span className="text-sm text-google-muted transition-colors group-hover:text-mineral-blue/72">
+        ({count})
+      </span>
+    </Link>
+  );
+};
+
 const PopoverButton = ({
-  label,
-  locale = defaultLocale,
+  aboutLabel,
+  aboutHref,
+  closeLabel,
+  homeHref,
+  homeLabel,
+  locale,
+  localeSwitchLabel,
+  menuLabel,
+  openLabel,
+  tagLabel,
+  tags,
 }: PopoverButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
+  const targetLocale = locale === defaultLocale ? "en" : defaultLocale;
+  const localeSwitchHref = getLocaleSwitchHref(locale, pathname);
+
+  const handleOpenClick = (): void => {
+    setIsOpen(true);
+  };
+
+  const handleCloseClick = (): void => {
+    setIsOpen(false);
+  };
+
+  /**
+   * Keep the mobile menu modal by locking the page behind it and allowing Escape to close it while open.
+   */
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const rootElement = document.documentElement;
+    const hadOverflowHidden =
+      rootElement.classList.contains("overflow-hidden");
+
+    rootElement.classList.add("overflow-hidden");
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+
+      if (!hadOverflowHidden) {
+        rootElement.classList.remove("overflow-hidden");
+      }
+    };
+  }, [isOpen]);
+
   return (
     <div className="flex md:hidden">
-      <Link
-        href={getLocalizedPath(locale, "/popover")}
-        className="text-current opacity-80 hover:opacity-100"
-        aria-label={label}
+      <button
+        type="button"
+        aria-controls={mobileMenuPanelId}
+        aria-expanded={isOpen}
+        aria-label={openLabel}
+        className="inline-flex h-11 w-11 items-center justify-center text-current opacity-80 transition-opacity hover:opacity-100"
+        onClick={handleOpenClick}
       >
         <svg width="24" height="24">
           <path
@@ -30,7 +194,94 @@ const PopoverButton = ({
             strokeLinecap="round"
           />
         </svg>
-      </Link>
+      </button>
+
+      {isOpen &&
+        createPortal(
+          <div
+            id={mobileMenuPanelId}
+            role="dialog"
+            aria-modal="true"
+            aria-label={menuLabel}
+            className="fixed inset-0 z-50 overflow-y-auto bg-google-ink px-6 pb-10 pt-4 text-google-paper shadow-[0_0_80px_rgb(0_0_0/0.48)]"
+          >
+            <div className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-[480px] flex-col">
+              <div className="flex h-[58px] items-center justify-between">
+                <Link
+                  href={homeHref}
+                  aria-label="OU9999 home"
+                  className="flex h-10 w-[72px] items-center justify-center overflow-hidden"
+                  onClick={handleCloseClick}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="block h-full w-full bg-[url('/imgs/header/ou-symbol-negative-space-v1.webp')] bg-[length:116%_auto] bg-center bg-no-repeat"
+                  />
+                </Link>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  aria-label={closeLabel}
+                  className="inline-flex h-11 w-11 items-center justify-center fill-google-paper/82 transition-colors hover:fill-mineral-blue"
+                  onClick={handleCloseClick}
+                >
+                  <XIcon />
+                </button>
+              </div>
+
+              <nav
+                aria-label={menuLabel}
+                className="mt-12 flex flex-col items-center"
+              >
+                <p className="font-brand text-[44px] font-semibold leading-none text-google-paper">
+                  {menuLabel}
+                </p>
+                <div className="mt-7 flex flex-col items-center gap-5">
+                  <MobileMenuLink
+                    href={homeHref}
+                    text={homeLabel}
+                    onClick={handleCloseClick}
+                  />
+                  <MobileMenuLink
+                    href={aboutHref}
+                    text={aboutLabel}
+                    onClick={handleCloseClick}
+                  />
+                  <MobileMenuLink
+                    href={localeSwitchHref}
+                    lang={targetLocale}
+                    text={localeSwitchLabel}
+                    onClick={handleCloseClick}
+                  />
+                </div>
+              </nav>
+
+              <section
+                aria-labelledby="mobile-menu-tags-heading"
+                className="mt-14 flex flex-col items-center"
+              >
+                <p
+                  id="mobile-menu-tags-heading"
+                  className="font-brand text-[44px] font-semibold leading-none text-google-paper"
+                >
+                  {tagLabel}
+                </p>
+                <div className="mt-7 flex flex-col items-center gap-4">
+                  {tags.map((tag) => (
+                    <TagItem
+                      key={"MOBILEMENUTAG" + tag.tag}
+                      title={tag.tag}
+                      count={tag.count}
+                      locale={locale}
+                      onClick={handleCloseClick}
+                    />
+                  ))}
+                </div>
+              </section>
+            </div>
+          </div>,
+          document.body
+        )}
     </div>
   );
 };

--- a/src/components/nav/site-footer.tsx
+++ b/src/components/nav/site-footer.tsx
@@ -40,13 +40,11 @@ const Footer = () => {
 
       <div className="relative mx-auto flex w-full max-w-[1320px] flex-col gap-14 pt-36 md:flex-row md:items-end md:justify-between md:gap-12 md:pt-40">
         <div className="max-w-[570px]">
-          <p className="font-brand text-3xl font-normal leading-none tracking-[0.18em] text-google-paper/82 md:text-[34px]">
-            Only Clear Later
+          <p className="font-brand text-3xl font-normal leading-none tracking-[0.18em] lining-nums text-google-paper/82 md:text-[34px]">
+            OU9999
           </p>
           <p className="mt-7 max-w-[560px] text-lg leading-9 text-google-paper/66 md:text-[19px]">
-            I write to understand what was, to connect what is,{" "}
-            <br className="hidden md:block" />
-            and to prepare for what&apos;s next.
+            Some thoughts only find their shape later
           </p>
         </div>
 

--- a/src/components/nav/site-header.tsx
+++ b/src/components/nav/site-header.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { getLocalizedPath, type AppLocale } from "@/i18n/config";
-import { hoverMineralTextGradient } from "../common/styles";
-import { cn } from "@/utils/tailwind-util";
 import { HeaderFrame } from "./header/header-frame";
+import { HeaderNavLink } from "./header/header-nav-link";
 import { LocaleSwitchLink } from "./header/locale-switch-link";
 import { PopoverButton } from "./header/popover-button";
 
@@ -32,32 +31,10 @@ const Header = async ({ locale }: HeaderProps) => {
           />
         </Link>
 
-        <div className="relative z-10 hidden items-center md:flex">
-          <Link href={homeHref} className="mr-[57px]">
-            <p
-              className={cn(
-                "translate-y-px font-brand text-xl font-normal leading-none text-google-paper",
-                hoverMineralTextGradient
-              )}
-            >
-              {t("home")}
-            </p>
-          </Link>
-          <Link href={aboutHref} className="mr-[38px]">
-            <p
-              className={cn(
-                "translate-y-px font-brand text-xl font-normal leading-none text-google-paper",
-                hoverMineralTextGradient
-              )}
-            >
-              {t("about")}
-            </p>
-          </Link>
-          <LocaleSwitchLink
-            label={localeSwitchLabel}
-            locale={locale}
-            variant="stamp"
-          />
+        <div className="relative z-10 hidden items-center gap-[54px] md:flex">
+          <HeaderNavLink href={homeHref} label={t("home")} />
+          <HeaderNavLink href={aboutHref} label={t("about")} />
+          <LocaleSwitchLink label={localeSwitchLabel} locale={locale} />
         </div>
         <div className="relative z-10 md:hidden">
           <PopoverButton label={t("openMenu")} locale={locale} />

--- a/src/components/nav/site-header.tsx
+++ b/src/components/nav/site-header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { getLocalizedPath, type AppLocale } from "@/i18n/config";
+import { getTagsFromPosts } from "@/utils/post-util";
 import { HeaderFrame } from "./header/header-frame";
 import { HeaderNavLink } from "./header/header-nav-link";
 import { LocaleSwitchLink } from "./header/locale-switch-link";
@@ -11,7 +12,10 @@ interface HeaderProps {
 }
 
 const Header = async ({ locale }: HeaderProps) => {
-  const t = await getTranslations({ locale, namespace: "Navigation" });
+  const [t, tagsCount] = await Promise.all([
+    getTranslations({ locale, namespace: "Navigation" }),
+    getTagsFromPosts(locale),
+  ]);
   const homeHref = getLocalizedPath(locale, "/");
   const aboutHref = getLocalizedPath(locale, "/about");
   const localeSwitchLabel = locale === "ko" ? t("en") : t("ko");
@@ -37,7 +41,19 @@ const Header = async ({ locale }: HeaderProps) => {
           <LocaleSwitchLink label={localeSwitchLabel} locale={locale} />
         </div>
         <div className="relative z-10 md:hidden">
-          <PopoverButton label={t("openMenu")} locale={locale} />
+          <PopoverButton
+            aboutHref={aboutHref}
+            aboutLabel={t("about")}
+            closeLabel={t("closeMenu")}
+            homeHref={homeHref}
+            homeLabel={t("home")}
+            locale={locale}
+            localeSwitchLabel={localeSwitchLabel}
+            menuLabel={t("menu")}
+            openLabel={t("openMenu")}
+            tagLabel={t("tag")}
+            tags={tagsCount}
+          />
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## 요약

- 데스크톱 헤더 내비게이션의 현재 페이지 표시와 hover 표현을 붓 질감 기준으로 통일함
- 모바일 메뉴를 전체 화면 패널로 전환하고 주요 이동 경로와 태그 탐색을 한 화면에서 제공함
- 푸터 브랜드 문구를 간결하게 정리함

### 헤더 내비게이션 정리

- 현재 페이지에는 붓 밑줄을 유지하고 hover/focus 상태에서는 강조 색상으로 전환되도록 조정함
- 언어 전환 항목도 같은 내비게이션 스타일을 사용해 데스크톱 헤더 표현을 통일함

### 모바일 메뉴 개선

- 메뉴 버튼이 전체 화면 패널을 열고 닫으며, 닫기와 Escape 동작을 지원하도록 구성함
- 홈, 소개, 언어 전환, 태그 목록을 모바일 메뉴 안에서 직접 접근할 수 있도록 추가함

### 푸터 문구 정리

- 브랜드 표기를 짧게 정리하고 보조 문구를 간결하게 바꿈