### PR TITLE
docs: 겁쟁이의 용기 영문판 추가

### DIFF
--- a/content/posts/en/courage.mdx
+++ b/content/posts/en/courage.mdx
@@ -1,0 +1,114 @@
+---
+title: A Coward's Courage
+description: Looking back at the parts of myself I had neglected while hiding behind development
+date: "2026-07-18"
+tags:
+  - essay
+thumbnail: courage
+published: true
+---
+
+## Familiar Work Began to Feel Unfamiliar
+
+AI seemed to be getting better at the work I believed I did best. I was afraid and anxious. I wondered whether writing code and sharing ways of developing software would continue to have the same meaning. Even my familiar role as a developer felt as if it were being shaken.
+
+In that anxiety, I thought about everything I had put off behind the familiar role of development.
+
+When AI became better at the work I thought I did best, why did I find myself looking back not at my development skills, but at the fears I had avoided?
+
+## I Saw What I Had Hidden Behind Development
+
+Development had been the easier path for me. That does not mean I was especially good at it or knew a great deal about computers. Compared with understanding people who thought differently from me, understanding code and solving problems felt comfortable.
+
+It was not that I failed to notice problems involving people. If anything, I was acutely aware of them and felt that they were too vast to solve. I often saw problems where others did not. I had watched even people with prestigious degrees and plenty of money fail to understand one another and lose sight of the problems they could solve together.
+
+Faced with those problems, I stepped back and told myself that development was the task given to me. I drew a line and decided that solving problems between people was not my role.
+
+It was similar when it came to putting myself out there. I now believe it matters to share my opinions and meet people on LinkedIn, X, and developer communities.
+
+Even though I knew that, I had never started using LinkedIn. I was ashamed of myself.
+
+In developer Discord servers and communities, I was afraid of being judged for sharing an opinion. I knew I could not be good from the beginning, yet I avoided places where I might look foolish, be disliked, and become the subject of judgment.
+
+That does not mean I have lived my whole life avoiding every challenge. I took on new things while becoming a developer and at my current company as well.
+
+What I avoided was not challenge itself. It was solving problems involving people, expressing myself, and being evaluated while my shortcomings were visible. Development was also a role that let me take one step back from those fears.
+
+<Image
+  src="/imgs/post/courage/shelter.webp"
+  width="1600"
+  height="900"
+  alt="A narrow beam of light between dark spaces and the edge of a laptop below the frame"
+  showCaption={false}
+/>
+
+The pressure and FOMO I felt as AI changed rapidly were certainly part of it. I could not deny the fear of falling behind.
+
+But I could not explain the talk solely as something I had rushed into, either. This time, I knew why I was doing it. My main reason was not to satisfy other people or follow along because everyone else was doing it.
+
+At a time when so much was changing, I wanted to accept the changes in myself that I had kept putting off. I felt there was no more time to delay and nowhere left to run. I decided to look directly at what I had avoided and move in a way I had never tried before.
+
+## I Created the Place I Had Been Waiting For
+
+I went to several meetups to learn about AI. The speakers described the paths they had taken in detail. Each shared successful outcomes and the impact those results had, as well as experiences of failure, in their own way. Talks like those sometimes motivated listeners to create something new.
+
+I envied environments where colleagues could share stories like that. I also envied people who brought their stories to a larger stage.
+
+After returning home, I thought about it for a long time. I realized that I had been waiting for the right environment and conditions while expecting other people to provide them.
+
+This time, I decided to create at least a small part of that environment myself. I decided to start by sharing the development approaches I valued and the problems I had solved from my own perspective.
+
+People can see the same thing and feel differently about it. The thought that something obvious to me might be unfamiliar to a colleague gave me a reason to propose the talk.
+
+Without overthinking it, I went to my team lead and said I wanted to give a talk. I asked to present not only to the developers, but to everyone in the company. In early May, I chose the title `Harness Engineering: The Power to Guide the Wild Horse Called the LLM`. I practiced while recording my own voice.
+
+I organized my experience with a sense of challenge, but the fear was always there. No matter how comfortable I felt around my coworkers, when I stood in front of a group, my eyes dropped and my voice trembled.
+
+Still, the thought that I could create the environment I wanted instead of only searching for it made me tremble with excitement and joy. I reached the day of the talk carrying both fear and joy.
+
+<Image
+  src="/imgs/post/courage/voice-trace.webp"
+  width="1600"
+  height="900"
+  alt="Faint brushstrokes spreading from a small recorder into an empty space"
+  showCaption={false}
+/>
+
+## I Looked Up from the Laptop Screen
+
+I had practiced while replaying the talk in my head, but everything changed when I actually stood in front of people. Despite the boldness I had felt at the start, my eyes gradually fixed on the small laptop screen and my voice grew quieter.
+
+I wondered whether I had turned a deeply personal realization into something too big by gathering my coworkers. I worried about whether my story was worth their time and whether I was using that time as a stepping stone for personal reasons.
+
+I remembered that I had chosen to accept being watched and judged. I decided to set my self-consciousness aside and focus on what I had wanted to do: put my experience into my own words and share it with my coworkers.
+
+In the middle of the talk, I suddenly raised my voice and shouted. After that, I found my confidence and my voice stopped trembling.
+
+As I continued, I looked up from the small laptop screen and faced the room. Some people looked bored, while others wore small smiles. A few of my coworkers had light in their eyes.
+
+I felt that my experience and feelings might reach some of them. From that moment, the talk no longer felt like a monologue waiting to be judged. It felt like a conversation with my coworkers. The tension eased as well.
+
+<Image
+  src="/imgs/post/courage/afterimage.webp"
+  width="1600"
+  height="900"
+  alt="Two overlapping paths of light beside an empty chair"
+  showCaption={false}
+/>
+
+## Some Things Remained Unknown After the Talk
+
+Afterward, one person applied something new to a project and then shared what they had done. Another stepped forward to prepare the next talk. I do not believe the entire company culture changed dramatically. I also cannot say that those two actions came from my talk.
+
+It is too soon to say that one talk changed an attitude I had put off for so long. I will still be nervous on a larger stage. I do not yet know whether I will make the same choice there.
+
+I am certain, however, that I can do better than I did the first time.
+
+<HighlightQuote
+  className="break-keep text-[2.75rem] leading-[1.12] lg:text-[4.25rem] lg:leading-[1.04]"
+  text="I no longer want to avoid showing the foolish side of myself."
+/>
+
+I may even begin to look forward to places like that.
+
+AI made me see the fears I had left behind the familiar role of development. Courage, for me, was not a state without fear. It was refusing to avoid a place where I could be judged with all my shortcomings visible. Looking up from the laptop screen in the middle of the talk and facing the people in front of me is the answer that remains with me now.


### PR DESCRIPTION
## Summary

- `겁쟁이의 용기` 포스트의 영문판을 추가했습니다.
- 원문의 섹션 구조, 이미지, 강조 문구와 메타데이터를 유지했습니다.

## Checks

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `playwright-cli`: `/en/p/courage` HTTP 200 및 영문 콘텐츠·이미지 렌더링 확인
- [x] `playwright-cli`: `/p/courage` ↔ `/en/p/courage` 언어 전환 확인
- [ ] Vercel Preview checked when UI, routing, or content rendering changed

## Notes

- 로컬 검증은 Node.js 25에서 실행되어 프로젝트 지정 Node.js 24 엔진 경고가 있었지만 lint와 build는 통과했습니다.
- 신규 경로라 Giscus discussion 미생성 404가 발생하며, 페이지 자원 오류는 없습니다.