### PR TITLE
refactor: 메인 태그 필터 제거

### DIFF
--- a/src/components/main-section/post-box.tsx
+++ b/src/components/main-section/post-box.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { hoverMineralTextGradient } from "../common/styles";
-import { Tag } from "../common/tag-link";
 import { formatDateToString } from "@/utils/date-util";
 import { cn } from "@/utils/tailwind-util";
 import { ImageWithPlaceholderHeader } from "../content-header/image-with-placeholder-header";
@@ -59,8 +58,13 @@ const PostBox = ({
         <p>{description}</p>
       </div>
       <div className="mt-5 flex w-full flex-wrap gap-2">
-        {tags.map((tag, idx) => (
-          <Tag key={"tag" + idx} tag={tag} variant="paper" locale={locale} />
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full border border-mineral-blue/32 px-3 py-1.5 font-mono text-base uppercase leading-none text-google-paper"
+          >
+            {tag}
+          </span>
         ))}
       </div>
     </article>


### PR DESCRIPTION
## 요약

- 메인 글 카드의 태그 필터 이동 동작 제거
- 태그 정보와 글 상세 진입 동작 유지

### 태그 상호작용 제거

- 태그 링크를 정적 배지로 변경해 클릭 시 태그별 글 목록으로 이동하지 않도록 함

### 기존 정보와 탐색 유지

- 태그 텍스트와 배지 형태는 유지하고 글 이미지와 제목을 통한 상세 페이지 이동은 그대로 유지함