### PR TITLE
release: 2026-07-20

### DIFF
--- a/src/components/main-section/post-box.tsx
+++ b/src/components/main-section/post-box.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { hoverMineralTextGradient } from "../common/styles";
-import { Tag } from "../common/tag-link";
 import { formatDateToString } from "@/utils/date-util";
 import { cn } from "@/utils/tailwind-util";
 import { ImageWithPlaceholderHeader } from "../content-header/image-with-placeholder-header";
@@ -59,8 +58,13 @@ const PostBox = ({
         <p>{description}</p>
       </div>
       <div className="mt-5 flex w-full flex-wrap gap-2">
-        {tags.map((tag, idx) => (
-          <Tag key={"tag" + idx} tag={tag} variant="paper" locale={locale} />
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full border border-mineral-blue/32 px-3 py-1.5 font-mono text-base uppercase leading-none text-google-paper"
+          >
+            {tag}
+          </span>
         ))}
       </div>
     </article>


### PR DESCRIPTION
## 요약

- 메인 글 카드의 태그 필터 동작 제거 변경을 release로 승격
- CI와 Vercel Production 배포 검증 진행

### Release 승격

- 태그 정보는 유지하고 필터 페이지 이동을 제거한 develop 변경사항을 release 브랜치에 반영함

### 배포 검증

- merge 후 release 브랜치 CI와 Vercel Production 배포 상태를 확인함